### PR TITLE
Handle errors in loadData method

### DIFF
--- a/build/playground-base.js
+++ b/build/playground-base.js
@@ -1203,9 +1203,14 @@ PLAYGROUND.Application.prototype = {
 
         this.loader.add(entry.url);
 
-        request.onload = function() {
+        request.onload = function(evt) {
+          var xhr = evt.target;
 
           console.log("ENTRY", entry);
+
+          if (xhr.status !== 200) {
+            return app.loader.error(entry.url);
+          }
 
           if (entry.ext === "json") {
             app.data[entry.key] = JSON.parse(this.responseText);

--- a/build/playground.js
+++ b/build/playground.js
@@ -1203,9 +1203,14 @@ PLAYGROUND.Application.prototype = {
 
         this.loader.add(entry.url);
 
-        request.onload = function() {
+        request.onload = function(evt) {
+          var xhr = evt.target;
 
           console.log("ENTRY", entry);
+
+          if (xhr.status !== 200) {
+            return app.loader.error(entry.url);
+          }
 
           if (entry.ext === "json") {
             app.data[entry.key] = JSON.parse(this.responseText);

--- a/docs/script/playground-base.js
+++ b/docs/script/playground-base.js
@@ -1203,9 +1203,14 @@ PLAYGROUND.Application.prototype = {
 
         this.loader.add(entry.url);
 
-        request.onload = function() {
+        request.onload = function(evt) {
+          var xhr = evt.target;
 
           console.log("ENTRY", entry);
+
+          if (xhr.status !== 200) {
+            return app.loader.error(entry.url);
+          }
 
           if (entry.ext === "json") {
             app.data[entry.key] = JSON.parse(this.responseText);

--- a/docs/script/playground.js
+++ b/docs/script/playground.js
@@ -1203,9 +1203,14 @@ PLAYGROUND.Application.prototype = {
 
         this.loader.add(entry.url);
 
-        request.onload = function() {
+        request.onload = function(evt) {
+          var xhr = evt.target;
 
           console.log("ENTRY", entry);
+
+          if (xhr.status !== 200) {
+            return app.loader.error(entry.url);
+          }
 
           if (entry.ext === "json") {
             app.data[entry.key] = JSON.parse(this.responseText);

--- a/docs/standalone/playground-base/script/lib/playground.js
+++ b/docs/standalone/playground-base/script/lib/playground.js
@@ -1203,9 +1203,14 @@ PLAYGROUND.Application.prototype = {
 
         this.loader.add(entry.url);
 
-        request.onload = function() {
+        request.onload = function(evt) {
+          var xhr = evt.target;
 
           console.log("ENTRY", entry);
+
+          if (xhr.status !== 200) {
+            return app.loader.error(entry.url);
+          }
 
           if (entry.ext === "json") {
             app.data[entry.key] = JSON.parse(this.responseText);

--- a/docs/standalone/playground/script/lib/playground.js
+++ b/docs/standalone/playground/script/lib/playground.js
@@ -1203,9 +1203,14 @@ PLAYGROUND.Application.prototype = {
 
         this.loader.add(entry.url);
 
-        request.onload = function() {
+        request.onload = function(evt) {
+          var xhr = evt.target;
 
           console.log("ENTRY", entry);
+
+          if (xhr.status !== 200) {
+            return app.loader.error(entry.url);
+          }
 
           if (entry.ext === "json") {
             app.data[entry.key] = JSON.parse(this.responseText);

--- a/src/Application.js
+++ b/src/Application.js
@@ -306,9 +306,14 @@ PLAYGROUND.Application.prototype = {
 
         this.loader.add(entry.url);
 
-        request.onload = function() {
+        request.onload = function(evt) {
+          var xhr = evt.target;
 
           console.log("ENTRY", entry);
+
+          if (xhr.status !== 200) {
+            return app.loader.error(entry.url);
+          }
 
           if (entry.ext === "json") {
             app.data[entry.key] = JSON.parse(this.responseText);


### PR DESCRIPTION
Avoid crashing the app if the json file doesn't load via the `loadData` method.

If we don't get a `200` status, we return with a `app.loader.error`.
This way we don't parse something nonexistent.

---

On a sidenote, 
I couldn't create the zip files with the build.
Can you help me with the build process @rezoner.
I guess that you're on a mac because I couldn't find a `zip` command for windows.

Awesome framework :+1:
