### PR TITLE
Using consistent loader ids in three.js plugin

### DIFF
--- a/plugins/playground.three.js
+++ b/plugins/playground.three.js
@@ -22,7 +22,7 @@
 
     if (this.textures[assetPath.key]) return;
 
-    this.loader.add(name);
+    this.loader.add(resourceName);
 
     var loader = new THREE.TextureLoader();
 
@@ -55,7 +55,7 @@
 
     if (this.objects[assetPath.key]) return;
 
-    this.loader.add(name);
+    this.loader.add(loaderID);
 
     var loader = new THREE.ObjectLoader();
 


### PR DESCRIPTION
The three.js plugin did not supply an ID to the loader when adding a resource, because "name" was not defined. Changed the parameter to the actual ID for both helpers.
