### PR TITLE
Added the ability to load via `require`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/build.js
+++ b/build.js
@@ -62,4 +62,9 @@ for (var key in builds) {
 
   output.to("build/" + key);
 
+  output = 'var PLAYGROUND;\n' + output;
+  output += '\nmodule.exports = playground;';
+  output += 'playground.Application = PLAYGROUND.Application;';
+  output.to("build/commonjs/" + key);
+
 }

--- a/build/commonjs/playground-base.js
+++ b/build/commonjs/playground-base.js
@@ -1,0 +1,3248 @@
+var PLAYGROUND;
+
+
+/* file: license.txt */
+
+/*     
+
+  PlaygroundJS r5
+  
+  http://playgroundjs.com
+  
+  (c) 2012-2015 http://rezoner.net
+  
+  Playground may be freely distributed under the MIT license.
+
+  latest major changes:
+
+  r5
+
+  + game loop nicely split into render and step - check profiler
+  + fixed loader last item
+  + fixed some flow issues
+  + imageready event
+  + loadFont
+  + gamepad stick issue
+  + pointerwheel event
+  + updated CanvasQuery
+  - removed video recorder  
+
+  r4
+
+  + tweens with events
+  + context argument for events
+
+  r3
+
+  + pointer = mouse + touch
+
+*/
+
+
+/* file: src/lib/Ease.js */
+
+/*     
+
+  Ease 1.0
+  
+  http://canvasquery.com
+  
+  (c) 2015 by Rezoner - http://rezoner.net
+
+  `ease` may be freely distributed under the MIT license.
+
+*/
+
+(function() {
+
+  var ease = function(progress, easing) {
+
+    if (typeof ease.cache[easing] === "function") {
+
+      return ease.cache[easing](progress);
+
+    } else {
+
+      return ease.spline(progress, easing || ease.defaultEasing);
+
+    }
+
+  };
+
+  var extend = function() {
+    for (var i = 1; i < arguments.length; i++) {
+      for (var j in arguments[i]) {
+        arguments[0][j] = arguments[i][j];
+      }
+    }
+
+    return arguments[0];
+  };
+
+  extend(ease, {
+
+    defaultEasing: "016",
+
+    cache: {
+
+      linear: function(t) {
+        return t
+      },
+
+      inQuad: function(t) {
+        return t * t
+      },
+      outQuad: function(t) {
+        return t * (2 - t)
+      },
+      inOutQuad: function(t) {
+        return t < .5 ? 2 * t * t : -1 + (4 - 2 * t) * t
+      },
+      inCubic: function(t) {
+        return t * t * t
+      },
+      outCubic: function(t) {
+        return (--t) * t * t + 1
+      },
+      inOutCubic: function(t) {
+        return t < .5 ? 4 * t * t * t : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1
+      },
+      inQuart: function(t) {
+        return t * t * t * t
+      },
+      outQuart: function(t) {
+        return 1 - (--t) * t * t * t
+      },
+      inOutQuart: function(t) {
+        return t < .5 ? 8 * t * t * t * t : 1 - 8 * (--t) * t * t * t
+      },
+      inQuint: function(t) {
+        return t * t * t * t * t
+      },
+      outQuint: function(t) {
+        return 1 + (--t) * t * t * t * t
+      },
+      inOutQuint: function(t) {
+        return t < .5 ? 16 * t * t * t * t * t : 1 + 16 * (--t) * t * t * t * t
+      },
+      inSine: function(t) {
+        return -1 * Math.cos(t / 1 * (Math.PI * 0.5)) + 1;
+      },
+      outSine: function(t) {
+        return Math.sin(t / 1 * (Math.PI * 0.5));
+      },
+      inOutSine: function(t) {
+        return -1 / 2 * (Math.cos(Math.PI * t) - 1);
+      },
+      inExpo: function(t) {
+        return (t == 0) ? 0 : Math.pow(2, 10 * (t - 1));
+      },
+      outExpo: function(t) {
+        return (t == 1) ? 1 : (-Math.pow(2, -10 * t) + 1);
+      },
+      inOutExpo: function(t) {
+        if (t == 0) return 0;
+        if (t == 1) return 1;
+        if ((t /= 1 / 2) < 1) return 1 / 2 * Math.pow(2, 10 * (t - 1));
+        return 1 / 2 * (-Math.pow(2, -10 * --t) + 2);
+      },
+      inCirc: function(t) {
+        return -1 * (Math.sqrt(1 - t * t) - 1);
+      },
+      outCirc: function(t) {
+        return Math.sqrt(1 - (t = t - 1) * t);
+      },
+      inOutCirc: function(t) {
+        if ((t /= 1 / 2) < 1) return -1 / 2 * (Math.sqrt(1 - t * t) - 1);
+        return 1 / 2 * (Math.sqrt(1 - (t -= 2) * t) + 1);
+      },
+      inElastic: function(t) {
+        var s = 1.70158;
+        var p = 0;
+        var a = 1;
+        if (t == 0) return 0;
+        if (t == 1) return 1;
+        if (!p) p = 0.3;
+        if (a < 1) {
+          a = 1;
+          var s = p / 4;
+        } else var s = p / (2 * Math.PI) * Math.asin(1 / a);
+        return -(a * Math.pow(2, 10 * (t -= 1)) * Math.sin((t - s) * (2 * Math.PI) / p));
+      },
+      outElastic: function(t) {
+        var s = 1.70158;
+        var p = 0;
+        var a = 1;
+        if (t == 0) return 0;
+        if (t == 1) return 1;
+        if (!p) p = 0.3;
+        if (a < 1) {
+          a = 1;
+          var s = p / 4;
+        } else var s = p / (2 * Math.PI) * Math.asin(1 / a);
+        return a * Math.pow(2, -10 * t) * Math.sin((t - s) * (2 * Math.PI) / p) + 1;
+      },
+      inOutElastic: function(t) {
+        var s = 1.70158;
+        var p = 0;
+        var a = 1;
+        if (t == 0) return 0;
+        if ((t /= 1 / 2) == 2) return 1;
+        if (!p) p = (0.3 * 1.5);
+        if (a < 1) {
+          a = 1;
+          var s = p / 4;
+        } else var s = p / (2 * Math.PI) * Math.asin(1 / a);
+        if (t < 1) return -.5 * (a * Math.pow(2, 10 * (t -= 1)) * Math.sin((t - s) * (2 * Math.PI) / p));
+        return a * Math.pow(2, -10 * (t -= 1)) * Math.sin((t - s) * (2 * Math.PI) / p) * 0.5 + 1;
+      },
+      inBack: function(t, s) {
+        if (s == undefined) s = 1.70158;
+        return 1 * t * t * ((s + 1) * t - s);
+      },
+      outBack: function(t, s) {
+        if (s == undefined) s = 1.70158;
+        return 1 * ((t = t / 1 - 1) * t * ((s + 1) * t + s) + 1);
+      },
+      inOutBack: function(t, s) {
+        if (s == undefined) s = 1.70158;
+        if ((t /= 1 / 2) < 1) return 1 / 2 * (t * t * (((s *= (1.525)) + 1) * t - s));
+        return 1 / 2 * ((t -= 2) * t * (((s *= (1.525)) + 1) * t + s) + 2);
+      },
+      inBounce: function(t) {
+        return 1 - this.outBounce(1 - t);
+      },
+      outBounce: function(t) {
+        if ((t /= 1) < (1 / 2.75)) {
+          return (7.5625 * t * t);
+        } else if (t < (2 / 2.75)) {
+          return (7.5625 * (t -= (1.5 / 2.75)) * t + .75);
+        } else if (t < (2.5 / 2.75)) {
+          return (7.5625 * (t -= (2.25 / 2.75)) * t + .9375);
+        } else {
+          return (7.5625 * (t -= (2.625 / 2.75)) * t + .984375);
+        }
+      },
+      inOutBounce: function(t) {
+        if (t < 1 / 2) return this.inBounce(t * 2) * 0.5;
+        return this.outBounce(t * 2 - 1) * 0.5 + 0.5;
+      }
+    },
+
+    translateEasing: function(key) {
+
+      if (!this.cache[key]) {
+        var array = key.split('');
+
+        var sign = 1;
+        var signed = false;
+
+        for (var i = 0; i < array.length; i++) {
+
+          var char = array[i];
+
+          if (char === "-") {
+            sign = -1;
+            signed = true;
+            array.splice(i--, 1);
+          } else if (char === "+") {
+            sign = 1;
+            array.splice(i--, 1);
+          } else array[i] = parseInt(array[i], 16) * sign;
+
+        }
+
+        var min = Math.min.apply(null, array);
+        var max = Math.max.apply(null, array);
+        var diff = max - min;
+        var cache = [];
+        var normalized = [];
+
+        for (var i = 0; i < array.length; i++) {
+          if (signed) {
+            var diff = Math.max(Math.abs(min), Math.abs(max))
+            normalized.push((array[i]) / diff);
+          } else {
+            var diff = max - min;
+            normalized.push((array[i] - min) / diff);
+          }
+        }
+
+        this.cache[key] = normalized;
+
+      }
+
+      return this.cache[key]
+
+    },
+
+    /* 
+      
+      Cubic-spline interpolation by Ivan Kuckir
+
+      http://blog.ivank.net/interpolation-with-cubic-splines.html
+
+      With slight modifications by Morgan Herlocker
+
+      https://github.com/morganherlocker/cubic-spline
+
+    */
+
+    splineK: {},
+    splineX: {},
+    splineY: {},
+
+    insertIntermediateValues: function(a) {
+      var result = [];
+      for (var i = 0; i < a.length; i++) {
+        result.push(a[i]);
+
+        if (i < a.length - 1) result.push(a[i + 1] + (a[i] - a[i + 1]) * 0.6);
+      }
+
+      return result;
+    },
+
+    spline: function(x, key) {
+
+      if (!this.splineK[key]) {
+
+        var xs = [];
+        var ys = this.translateEasing(key);
+
+        // ys = this.insertIntermediateValues(ys);
+
+        if (!ys.length) return 0;
+
+        for (var i = 0; i < ys.length; i++) xs.push(i * (1 / (ys.length - 1)));
+
+        var ks = xs.map(function() {
+          return 0
+        });
+
+        ks = this.getNaturalKs(xs, ys, ks);
+
+        this.splineX[key] = xs;
+        this.splineY[key] = ys;
+        this.splineK[key] = ks;
+
+      }
+
+      if (x > 1) return this.splineY[key][this.splineY[key].length - 1];
+
+      var ks = this.splineK[key];
+      var xs = this.splineX[key];
+      var ys = this.splineY[key];
+
+      var i = 1;
+
+      while (xs[i] < x) i++;
+
+      var t = (x - xs[i - 1]) / (xs[i] - xs[i - 1]);
+      var a = ks[i - 1] * (xs[i] - xs[i - 1]) - (ys[i] - ys[i - 1]);
+      var b = -ks[i] * (xs[i] - xs[i - 1]) + (ys[i] - ys[i - 1]);
+      var q = (1 - t) * ys[i - 1] + t * ys[i] + t * (1 - t) * (a * (1 - t) + b * t);
+
+      /*
+      var py = ys[i - 2];
+      var cy = ys[i - 1];
+      var ny = (i < ys.length - 1) ? ys[i] : ys[i - 1];
+
+      if (q > ny) {
+        var diff = (q - py);
+        //q = py + diff;
+
+      }
+
+    if (cy === ny && cy === py) q = py;
+    */
+
+
+      return q;
+    },
+
+    getNaturalKs: function(xs, ys, ks) {
+      var n = xs.length - 1;
+      var A = this.zerosMat(n + 1, n + 2);
+
+      for (var i = 1; i < n; i++) // rows
+      {
+        A[i][i - 1] = 1 / (xs[i] - xs[i - 1]);
+        A[i][i] = 2 * (1 / (xs[i] - xs[i - 1]) + 1 / (xs[i + 1] - xs[i]));
+        A[i][i + 1] = 1 / (xs[i + 1] - xs[i]);
+        A[i][n + 1] = 3 * ((ys[i] - ys[i - 1]) / ((xs[i] - xs[i - 1]) * (xs[i] - xs[i - 1])) + (ys[i + 1] - ys[i]) / ((xs[i + 1] - xs[i]) * (xs[i + 1] - xs[i])));
+      }
+
+      A[0][0] = 2 / (xs[1] - xs[0]);
+      A[0][1] = 1 / (xs[1] - xs[0]);
+      A[0][n + 1] = 3 * (ys[1] - ys[0]) / ((xs[1] - xs[0]) * (xs[1] - xs[0]));
+
+      A[n][n - 1] = 1 / (xs[n] - xs[n - 1]);
+      A[n][n] = 2 / (xs[n] - xs[n - 1]);
+      A[n][n + 1] = 3 * (ys[n] - ys[n - 1]) / ((xs[n] - xs[n - 1]) * (xs[n] - xs[n - 1]));
+
+      return this.solve(A, ks);
+    },
+
+    solve: function(A, ks) {
+      var m = A.length;
+      for (var k = 0; k < m; k++) // column
+      {
+        // pivot for column
+        var i_max = 0;
+        var vali = Number.NEGATIVE_INFINITY;
+        for (var i = k; i < m; i++)
+          if (A[i][k] > vali) {
+            i_max = i;
+            vali = A[i][k];
+          }
+        this.splineSwapRows(A, k, i_max);
+
+        // for all rows below pivot
+        for (var i = k + 1; i < m; i++) {
+          for (var j = k + 1; j < m + 1; j++)
+            A[i][j] = A[i][j] - A[k][j] * (A[i][k] / A[k][k]);
+          A[i][k] = 0;
+        }
+      }
+      for (var i = m - 1; i >= 0; i--) // rows = columns
+      {
+        var v = A[i][m] / A[i][i];
+        ks[i] = v;
+        for (var j = i - 1; j >= 0; j--) // rows
+        {
+          A[j][m] -= A[j][i] * v;
+          A[j][i] = 0;
+        }
+      }
+      return ks;
+    },
+
+    zerosMat: function(r, c) {
+      var A = [];
+      for (var i = 0; i < r; i++) {
+        A.push([]);
+        for (var j = 0; j < c; j++) A[i].push(0);
+      }
+      return A;
+    },
+
+    splineSwapRows: function(m, k, l) {
+      var p = m[k];
+      m[k] = m[l];
+      m[l] = p;
+    }
+  });
+
+window.ease = ease;
+
+})();
+
+
+/* file: src/Playground.js */
+
+PLAYGROUND = {};
+
+function playground(args) {
+
+  return new PLAYGROUND.Application(args);
+
+};
+
+/* file: src/Utils.js */
+
+PLAYGROUND.Utils = {
+
+  extend: function() {
+
+    for (var i = 1; i < arguments.length; i++) {
+      for (var j in arguments[i]) {
+        arguments[0][j] = arguments[i][j];
+      }
+    }
+
+    return arguments[0];
+
+  },
+
+  merge: function(a) {
+
+    for (var i = 1; i < arguments.length; i++) {
+
+      var b = arguments[i];
+
+      for (var key in b) {
+
+        var value = b[key];
+
+        if (typeof a[key] !== "undefined") {
+          if (typeof a[key] === "object") this.merge(a[key], value);
+          else a[key] = value;
+        } else {
+          a[key] = value;
+        }
+      }
+    }
+    return a;
+
+  },
+
+  invoke: function(object, methodName) {
+
+    var args = Array.prototype.slice.call(arguments, 2);
+
+    for (var i = 0; i < object.length; i++) {
+      var current = object[i];
+
+      if (current[methodName]) current[methodName].apply(current, args);
+
+    }
+
+  },
+
+  throttle: function(fn, threshold) {
+    threshold || (threshold = 250);
+    var last,
+      deferTimer;
+    return function() {
+      var context = this;
+
+      var now = +new Date,
+        args = arguments;
+      if (last && now < last + threshold) {
+        // hold on to it
+        clearTimeout(deferTimer);
+        deferTimer = setTimeout(function() {
+          last = now;
+          fn.apply(context, args);
+        }, threshold);
+      } else {
+        last = now;
+        fn.apply(context, args);
+      }
+    };
+  }
+
+};
+
+PLAYGROUND.Utils.ease = ease;
+
+
+/* file: src/Events.js */
+
+PLAYGROUND.Events = function() {
+
+  this.listeners = {};
+
+};
+
+PLAYGROUND.Events.prototype = {
+
+  on: function(event, callback, context) {
+
+    if (typeof event === "object") {
+      var result = {};
+      for (var key in event) {
+        result[key] = this.on(key, event[key], context)
+      }
+      return result;
+    }
+
+    if (!this.listeners[event]) this.listeners[event] = [];
+
+    var listener = {
+      once: false,
+      callback: callback,
+      context: context
+    };
+
+    this.listeners[event].push(listener);
+
+    return listener;
+  },
+
+  once: function(event, callback, context) {
+
+    if (typeof event === "object") {
+      var result = {};
+      for (var key in event) {
+        result[key] = this.once(key, event[key], context)
+      }
+      return result;
+    }
+
+    if (!this.listeners[event]) this.listeners[event] = [];
+
+    var listener = {
+      once: true,
+      callback: callback,
+      context: context
+    };
+
+    this.listeners[event].push(listener);
+
+    return listener;
+  },
+
+  off: function(event, callback) {
+
+    for (var i = 0, len = this.listeners[event].length; i < len; i++) {
+      if (this.listeners[event][i]._remove) {
+        this.listeners[event].splice(i--, 1);
+        len--;
+      }
+    }
+
+  },
+
+  trigger: function(event, data) {
+
+    /* if you prefer events pipe */
+
+    if (this.listeners["event"]) {
+
+      for (var i = 0, len = this.listeners["event"].length; i < len; i++) {
+
+        var listener = this.listeners["event"][i];
+
+        listener.callback.call(listener.context || this, event, data);
+
+      }
+
+    }
+
+    /* or subscribed to single event */
+
+    if (this.listeners[event]) {
+      for (var i = 0, len = this.listeners[event].length; i < len; i++) {
+
+        var listener = this.listeners[event][i];
+
+        listener.callback.call(listener.context || this, data);
+
+        if (listener.once) {
+          this.listeners[event].splice(i--, 1);
+          len--;
+        }
+      }
+    }
+
+  }
+
+};
+
+/* file: src/States.js */
+
+PLAYGROUND.States = function(app) {
+
+  this.app = app;
+
+  PLAYGROUND.Events.call(this);
+
+  app.on("step", this.step.bind(this));
+
+};
+
+PLAYGROUND.States.prototype = {
+
+  step: function(delta) {
+
+    if (!this.next) return;
+
+    if (this.current && this.current.locked) return;
+
+    var state = this.next;
+
+    if(typeof state === "function") state = new state;
+
+    /* create state if object has never been used as a state before */
+
+    if (!state.__created) {
+
+      state.__created = true;
+
+      state.app = this.app;
+
+      this.trigger("createstate", {
+        state: state
+      });
+
+      if (state.create) state.create();
+
+    }
+
+    /* enter new state */
+
+    if (this.current) {
+      this.trigger("leavestate", {
+        prev: this.current,
+        next: state,
+        state: this.current
+      });
+    }
+
+    this.trigger("enterstate", {
+      prev: this.current,
+      next: state,
+      state: state
+    });
+
+    this.current = state;
+
+    if (this.current && this.current.enter) {
+      this.current.enter();
+    }
+
+    this.app.state = this.current;
+
+    this.next = false;
+
+
+  },
+
+  set: function(state) {
+
+    if (this.current && this.current.leave) this.current.leave();
+
+    this.next = state;
+
+    this.step(0);
+
+  }
+
+
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.States.prototype, PLAYGROUND.Events.prototype);
+
+/* file: src/Application.js */
+
+PLAYGROUND.Application = function(args) {
+
+  var app = this;
+
+  /* events */
+
+  PLAYGROUND.Events.call(this);
+
+  /* defaults */
+
+  PLAYGROUND.Utils.merge(this, this.defaults, args);
+
+  /* guess scaling mode */
+
+  this.autoWidth = this.width ? false : true;
+  this.autoHeight = this.height ? false : true;
+  this.autoScale = this.scale ? false : true;
+
+  /* get container */
+
+  if (!this.container) this.container = document.body;
+
+  if (this.container !== document.body) this.customContainer = true;
+
+  if (typeof this.container === "string") this.container = document.querySelector(this.container);
+
+  this.updateSize();
+
+  /* events */
+
+  // this.emitLocalEvent = this.emitLocalEvent.bind(this);
+  // this.emitGlobalEvent = this.emitGlobalEvent.bind(this);
+
+  /* states manager */
+
+  this.states = new PLAYGROUND.States(this);
+  this.states.on("event", this.emitLocalEvent, this);
+
+  /* mouse */
+
+  this.mouse = new PLAYGROUND.Mouse(this, this.container);
+  this.mouse.on("event", this.emitGlobalEvent, this);
+
+  /* touch */
+
+  this.touch = new PLAYGROUND.Touch(this, this.container);
+  this.touch.on("event", this.emitGlobalEvent, this);
+
+  /* keyboard */
+
+  this.keyboard = new PLAYGROUND.Keyboard();
+  this.keyboard.on("event", this.emitGlobalEvent, this);
+
+  /* gamepads */
+
+  this.gamepads = new PLAYGROUND.Gamepads(this);
+  this.gamepads.on("event", this.emitGlobalEvent, this);
+
+  /* tweens */
+
+  this.tweens = new PLAYGROUND.TweenManager(this);
+
+  /* ease */
+
+  this.ease = PLAYGROUND.Utils.ease;
+
+  /* video recorder */
+
+  // this.videoRecorder = new PLAYGROUND.VideoRecorder(this);
+
+  /* sound */
+
+  PLAYGROUND.Sound(this);
+
+  /* window resize */
+
+  window.addEventListener("resize", this.handleResize.bind(this));
+
+  /* assets containers */
+
+  this.images = {};
+  this.atlases = {};
+  this.data = {};
+
+  this.loader = new PLAYGROUND.Loader(this);
+
+  this.loadFoo(0.25);
+
+  /* create plugins in the same way */
+
+  this.plugins = [];
+
+  for (var key in PLAYGROUND) {
+
+    var property = PLAYGROUND[key];
+
+    if (property.plugin) this.plugins.push(new property(this));
+
+  }
+
+  /* flow */
+
+  this.emitGlobalEvent("preload");
+
+  this.firstBatch = true;
+
+  if (this.disabledUntilLoaded) this.skipEvents = true;
+
+  function onPreloadEnd() {
+
+    app.loadFoo(0.25);
+
+    /* run everything in the next frame */
+
+    setTimeout(function() {
+
+      app.emitLocalEvent("create");
+
+      app.setState(PLAYGROUND.DefaultState);
+      app.handleResize();
+
+      if (PLAYGROUND.LoadingScreen) app.setState(PLAYGROUND.LoadingScreen);
+
+      /* game loop */
+
+      PLAYGROUND.GameLoop(app);
+
+      /* stage proper loading step */
+
+      app.loader.once("ready", function() {
+
+        app.firstBatch = false;
+
+        if (app.disabledUntilLoaded) app.skipEvents = false;
+
+        app.setState(PLAYGROUND.DefaultState);
+
+        app.emitLocalEvent("ready");
+        app.handleResize();
+
+      });
+
+    });
+
+
+
+  };
+
+
+  this.loader.once("ready", onPreloadEnd);
+
+};
+
+PLAYGROUND.Application.prototype = {
+
+  defaults: {
+    smoothing: 1,
+    paths: {
+      base: "",
+      images: "images/"
+    },
+    offsetX: 0,
+    offsetY: 0,
+    skipEvents: false,
+    disabledUntilLoaded: true
+  },
+
+  setState: function(state) {
+
+    this.states.set(state);
+
+  },
+
+  getPath: function(to) {
+
+    return this.paths.base + (this.paths[to] || (to + "/"));
+
+  },
+
+  getAssetEntry: function(path, folder, defaultExtension) {
+
+    /* translate folder according to user provided paths 
+       or leave as is */
+
+    var folder = this.paths[folder] || (folder + "/");
+
+    var fileinfo = path.match(/(.*)\..*/);
+    var key = fileinfo ? fileinfo[1] : path;
+
+    var temp = path.split(".");
+    var basename = path;
+
+    if (temp.length > 1) {
+      var ext = temp.pop();
+      path = temp.join(".");
+    } else {
+      var ext = defaultExtension;
+      basename += "." + defaultExtension;
+    }
+
+    return {
+      key: key,
+      url: this.paths.base + folder + basename,
+      path: this.paths.base + folder + path,
+      ext: ext
+    };
+
+  },
+
+  /* events that shouldn't flow down to the state */
+
+  emitLocalEvent: function(event, data) {
+
+    this.trigger(event, data);
+
+    if ((event !== "render" || !this.skipEvents || this.loader.ready) && this[event]) this[event](data);
+
+  },
+
+  /* events that should be passed to the state */
+
+  emitGlobalEvent: function(event, data) {
+
+    if (!this.state) return this.emitLocalEvent(event, data);
+
+    this.trigger(event, data);
+
+    if ((event !== "render" || !this.skipEvents || this.loader.ready) && this.event) this.event(event, data);
+
+    if ((event !== "render" || !this.skipEvents || this.loader.ready) && this[event]) this[event](data);
+
+    if (this.state.event) this.state.event(event, data);
+
+    if (this.state[event]) this.state[event](data);
+
+    this.trigger("post" + event, data);
+
+    // if (this.state.proxy) this.state.proxy(event, data);
+
+  },
+
+  updateSize: function() {
+
+    if (this.customContainer) {
+
+      var containerWidth = this.container.offsetWidth;
+      var containerHeight = this.container.offsetHeight;
+
+    } else {
+
+      var containerWidth = window.innerWidth;
+      var containerHeight = window.innerHeight;
+
+    }
+
+    if (!this.autoScale && !this.autoWidth && !this.autoHeight) {
+
+    } else if (!this.autoHeight && this.autoWidth) {
+
+      if (this.autoScale) this.scale = containerHeight / this.height;
+
+      this.width = Math.ceil(containerWidth / this.scale);
+
+    } else if (!this.autoWidth && this.autoHeight) {
+
+      if (this.autoScale) this.scale = containerWidth / this.width;
+
+      this.height = Math.ceil(containerHeight / this.scale);
+
+
+    } else if (this.autoWidth && this.autoHeight && this.autoScale) {
+
+      this.scale = 1;
+      this.width = containerWidth;
+      this.height = containerHeight;
+
+    } else if (this.autoWidth && this.autoHeight) {
+
+      this.width = Math.ceil(containerWidth / this.scale);
+      this.height = Math.ceil(containerHeight / this.scale);
+
+    } else {
+
+      this.scale = Math.min(containerWidth / this.width, containerHeight / this.height);
+
+    }
+
+    this.offsetX = (containerWidth - this.width * this.scale) / 2 | 0;
+    this.offsetY = (containerHeight - this.height * this.scale) / 2 | 0;
+
+    this.center = {
+      x: this.width / 2 | 0,
+      y: this.height / 2 | 0
+    };
+
+  },
+
+  handleResize: function() {
+
+    this.updateSize();
+
+    this.mouse.handleResize();
+    this.touch.handleResize();
+
+    this.emitGlobalEvent("resize", {});
+
+  },
+
+  /* 
+    request a file over http 
+    it shall be later an abstraction using 'fs' in node-webkit
+
+    returns a promise
+  */
+
+  request: function(url) {
+
+    function promise(success, fail) {
+
+      var request = new XMLHttpRequest();
+
+      var app = this;
+
+      request.open("GET", url, true);
+
+      request.onload = function(event) {
+
+        var xhr = event.target;
+
+        if (xhr.status !== 200 && xhr.status !== 0) {
+
+          return fail(new Error("Failed to get " + url));
+
+        }
+
+        success(xhr);
+
+      }
+
+      request.send();
+
+    }
+
+    return new Promise(promise);
+
+  },
+
+  /* imaginary timeout to delay loading */
+
+  loadFoo: function(timeout) {
+
+    var loader = this.loader;
+
+    this.loader.add("foo " + timeout);
+
+    setTimeout(function() {
+
+      loader.success("foo " + timeout);
+
+    }, timeout * 1000);
+
+
+  },
+
+  /* data/json */
+
+  loadData: function() {
+
+    for (var i = 0; i < arguments.length; i++) {
+
+      var arg = arguments[i];
+
+      if (typeof arg === "object") {
+
+        for (var key in arg) this.loadData(arg[key]);
+
+      } else {
+
+        this.loadDataItem(arg);
+
+      }
+
+    }
+
+  },
+
+  loadDataItem: function(name) {
+
+    var entry = this.getAssetEntry(name, "data", "json");
+
+    var app = this;
+
+    this.loader.add();
+
+    this.request(entry.url).then(processData);
+
+    function processData(request) {
+
+      if (entry.ext === "json") {
+        app.data[entry.key] = JSON.parse(request.responseText);
+      } else {
+        app.data[entry.key] = request.responseText;
+      }
+
+      app.loader.success(entry.url);
+
+    }
+
+  },
+
+  /* images */
+
+  loadImage: function() {
+
+    return this.loadImages.apply(this, arguments);
+
+  },
+
+  loadImages: function() {
+
+    var promises = [];
+
+    for (var i = 0; i < arguments.length; i++) {
+
+      var arg = arguments[i];
+
+      /* polymorphism at its finest */
+
+      if (typeof arg === "object") {
+
+        for (var key in arg) promises = promises.concat(this.loadImages(arg[key]));
+
+      } else {
+
+        promises.push(this.loadOneImage(arg));
+
+      }
+
+    }
+
+    return Promise.all(promises);
+
+  },
+
+  loadOneImage: function(name) {
+
+    var app = this;
+
+    if (!this._imageLoaders) this._imageLoaders = {};
+
+    if (!this._imageLoaders[name]) {
+
+      var promise = function(resolve, reject) {
+
+        /* if argument is not an object/array let's try to load it */
+
+        var loader = app.loader;
+
+        var entry = app.getAssetEntry(name, "images", "png");
+
+        app.loader.add(entry.path);
+
+        var image = new Image;
+
+        image.addEventListener("load", function() {
+
+          app.images[entry.key] = image;
+
+          resolve(image);
+          loader.success(entry.url);
+
+          entry.image = image;
+
+          app.emitLocalEvent("imageready", entry);
+
+        });
+
+        image.addEventListener("error", function() {
+
+          reject("can't load " + entry.url);
+          loader.error(entry.url);
+
+        });
+
+        image.src = entry.url;
+
+      };
+
+      app._imageLoaders[name] = new Promise(promise);
+
+    }
+
+    return this._imageLoaders[name];
+
+  },
+
+  /* at this point it doesn't really load font
+     it just ensures the font has been loaded (use css font-face)
+  */
+
+  loadFont: function() {
+
+    var promises = [];
+
+    for (var i = 0; i < arguments.length; i++) {
+
+      var arg = arguments[i];
+
+      promises.push(this.loadFontItem(arg));
+
+    }
+
+    return Promise.all(promises);
+
+  },
+
+  loadFonts: function() {
+
+    return this.loadFont.apply(this, arguments);
+
+  },
+
+  loadFontItem: function(name) {
+
+    var app = this;
+
+    if (!this._fontPromises) this._fontPromises = {};
+
+    if (!this._fontPromises[name]) {
+
+      var promise = function(resolve, reject) {
+
+        app.loader.add("font " + name);
+
+        var checkingTimer = setInterval(function() {
+
+          var base = cq(100, 32).font("14px somethingrandom").fillStyle("#fff").textBaseline("top").fillText("lorem ipsum dolores sit", 0, 4);
+          var test = cq(100, 32).font("14px '" + name + "'").fillStyle("#fff").textBaseline("top").fillText("lorem ipsum dolores sit", 0, 4);
+
+          if (!cq.compare(base, test)) {
+
+            app.loader.success("font" + name);
+
+            clearInterval(checkingTimer);
+
+            resolve();
+
+          }
+
+        });
+
+      }
+
+      this._fontPromises[name] = new Promise(promise);
+
+    }
+
+    return this._fontPromises[name];
+
+  },
+
+
+  render: function() {
+
+  }
+
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Application.prototype, PLAYGROUND.Events.prototype);
+
+/* file: src/GameLoop.js */
+
+PLAYGROUND.GameLoop = function(app) {
+
+  app.lifetime = 0;
+  app.ops = 0;
+  app.opcost = 0;
+
+  var lastTick = Date.now();
+  var frame = 0;
+
+  function render(dt) {
+
+    app.emitGlobalEvent("prerender", dt)
+    app.emitGlobalEvent("render", dt)
+    app.emitGlobalEvent("postrender", dt)
+
+  };
+
+  function step(dt) {
+
+    app.emitGlobalEvent("step", dt)
+
+  };
+
+  function gameLoop() {
+
+    requestAnimationFrame(gameLoop);
+
+    if (app.frameskip) {
+      frame++;
+      if (frame === app.frameskip) {
+        frame = 0;
+      } else return;
+    }
+
+    var delta = Date.now() - lastTick;
+
+    lastTick = Date.now();
+
+    if (delta > 1000) return;
+
+    var dt = delta / 1000;
+
+    app.lifetime += dt;
+    app.elapsed = dt;
+
+    step(dt);
+    render(dt);
+
+    app.opcost = (Date.now() - lastTick) / 1000;
+    app.ops = 1000 / app.opcost;
+
+  };
+
+  requestAnimationFrame(gameLoop);
+
+};
+
+/* file: src/Gamepads.js */
+
+PLAYGROUND.Gamepads = function(app) {
+
+  this.app = app;
+
+  PLAYGROUND.Events.call(this);
+
+  this.getGamepads = navigator.getGamepads || navigator.webkitGetGamepads;
+
+  this.gamepadmoveEvent = {};
+  this.gamepaddownEvent = {};
+  this.gamepadupEvent = {};
+
+  this.gamepads = {};
+
+  this.app.on("step", this.step.bind(this));
+
+};
+
+PLAYGROUND.Gamepads.prototype = {
+
+  buttons: {
+    0: "1",
+    1: "2",
+    2: "3",
+    3: "4",
+    4: "l1",
+    5: "r1",
+    6: "l2",
+    7: "r2",
+    8: "select",
+    9: "start",
+    12: "up",
+    13: "down",
+    14: "left",
+    15: "right"
+  },
+
+  zeroState: function() {
+
+    var buttons = [];
+
+    for (var i = 0; i <= 15; i++) {
+      buttons.push({
+        pressed: false,
+        value: 0
+      });
+    }
+
+    return {
+      axes: [],
+      buttons: buttons
+    };
+
+  },
+
+  createGamepad: function() {
+
+    var result = {
+      buttons: {},
+      sticks: [{
+        x: 0,
+        y: 0
+      }, {
+        x: 0,
+        y: 0
+      }]
+    };
+
+
+    for (var i = 0; i < 16; i++) {
+      var key = this.buttons[i];
+      result.buttons[key] = false;
+    }
+
+    return result;
+
+  },
+
+  step: function() {
+
+    if (!navigator.getGamepads) return;
+
+    var gamepads = navigator.getGamepads();
+
+    for (var i = 0; i < gamepads.length; i++) {
+
+      var current = gamepads[i];
+
+      if (!current) continue;
+
+      if (!this[i]) this[i] = this.createGamepad();
+
+      /* have to concat the current.buttons because the are read-only */
+
+      var buttons = [].concat(current.buttons);
+
+      /* hack for missing  dpads */
+
+      for (var h = 12; h <= 15; h++) {
+        if (!buttons[h]) buttons[h] = {
+          pressed: false,
+          value: 0
+        };
+      }
+
+      var previous = this[i];
+
+      /* axes (sticks) to buttons */
+
+      if (current.axes) {
+
+        if (current.axes[0] < 0) buttons[14].pressed = true;
+        if (current.axes[0] > 0) buttons[15].pressed = true;
+        if (current.axes[1] < 0) buttons[12].pressed = true;
+        if (current.axes[1] > 0) buttons[13].pressed = true;
+
+        previous.sticks[0].x = current.axes[0];
+        previous.sticks[0].y = current.axes[1];
+        previous.sticks[1].x = current.axes[2];
+        previous.sticks[1].y = current.axes[3];
+
+      }
+
+      /* check buttons changes */
+
+      for (var j = 0; j < buttons.length; j++) {
+
+        var key = this.buttons[j];
+
+        /* gamepad down */
+
+        if (buttons[j].pressed && !previous.buttons[key]) {
+
+          previous.buttons[key] = true;
+          this.gamepaddownEvent.button = this.buttons[j];
+          this.gamepaddownEvent.gamepad = i;
+          this.trigger("gamepaddown", this.gamepaddownEvent);
+
+        }
+
+        /* gamepad up */
+        
+        else if (!buttons[j].pressed && previous.buttons[key]) {
+
+          previous.buttons[key] = false;
+          this.gamepadupEvent.button = this.buttons[j];
+          this.gamepadupEvent.gamepad = i;
+          this.trigger("gamepadup", this.gamepadupEvent);
+
+        }
+
+      }
+
+    }
+
+  }
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Gamepads.prototype, PLAYGROUND.Events.prototype);
+
+
+/* file: src/Keyboard.js */
+
+PLAYGROUND.Keyboard = function() {
+
+  PLAYGROUND.Events.call(this);
+
+  this.keys = {};
+
+  document.addEventListener("keydown", this.keydown.bind(this));
+  document.addEventListener("keyup", this.keyup.bind(this));
+  document.addEventListener("keypress", this.keypress.bind(this));
+
+  this.keydownEvent = {};
+  this.keyupEvent = {};
+
+  this.preventDefault = true;
+
+};
+
+PLAYGROUND.Keyboard.prototype = {
+
+  keycodes: {
+    37: "left",
+    38: "up",
+    39: "right",
+    40: "down",
+    45: "insert",
+    46: "delete",
+    8: "backspace",
+    9: "tab",
+    13: "enter",
+    16: "shift",
+    17: "ctrl",
+    18: "alt",
+    19: "pause",
+    20: "capslock",
+    27: "escape",
+    32: "space",
+    33: "pageup",
+    34: "pagedown",
+    35: "end",
+    36: "home",
+    112: "f1",
+    113: "f2",
+    114: "f3",
+    115: "f4",
+    116: "f5",
+    117: "f6",
+    118: "f7",
+    119: "f8",
+    120: "f9",
+    121: "f10",
+    122: "f11",
+    123: "f12",
+    144: "numlock",
+    145: "scrolllock",
+    186: "semicolon",
+    187: "equal",
+    188: "comma",
+    189: "dash",
+    190: "period",
+    191: "slash",
+    192: "graveaccent",
+    219: "openbracket",
+    220: "backslash",
+    221: "closebraket",
+    222: "singlequote"
+  },
+
+  keypress: function(e) {
+
+  },
+
+  bypassKeys: ["f12", "f5", "ctrl", "alt", "shift"],
+
+  keydown: function(e) {
+
+    if (e.which >= 48 && e.which <= 90) var keyName = String.fromCharCode(e.which).toLowerCase();
+    else var keyName = this.keycodes[e.which];
+
+    if (this.keys[keyName]) return;
+
+    this.keydownEvent.key = keyName;
+    this.keydownEvent.original = e;
+
+    this.keys[keyName] = true;
+
+    this.trigger("keydown", this.keydownEvent);
+
+    if (this.preventDefault && document.activeElement === document.body) {
+
+      var bypass = e.metaKey;
+
+      if (!bypass) {
+        for (var i = 0; i < this.bypassKeys.length; i++) {
+
+          if (this.keys[this.bypassKeys[i]]) {
+            bypass = true;
+            break
+          }
+
+        }
+      }
+
+      if (!bypass) {
+        e.returnValue = false;
+        e.keyCode = 0;
+        e.preventDefault();
+        e.stopPropagation();
+      }
+
+    }
+
+  },
+
+  keyup: function(e) {
+
+    if (e.which >= 48 && e.which <= 90) var keyName = String.fromCharCode(e.which).toLowerCase();
+    else var keyName = this.keycodes[e.which];
+
+    this.keyupEvent.key = keyName;
+    this.keyupEvent.original = e;
+
+    this.keys[keyName] = false;
+
+    this.trigger("keyup", this.keyupEvent);
+
+  }
+
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Keyboard.prototype, PLAYGROUND.Events.prototype);
+
+/* file: src/Pointer.js */
+
+PLAYGROUND.Pointer = function(app) {
+
+  this.app = app;
+
+  app.on("touchstart", this.touchstart, this);
+  app.on("touchend", this.touchend, this);
+  app.on("touchmove", this.touchmove, this);
+
+  app.on("mousemove", this.mousemove, this);
+  app.on("mousedown", this.mousedown, this);
+  app.on("mouseup", this.mouseup, this);
+  app.on("mousewheel", this.mousewheel, this);
+
+  this.pointers = app.pointers = {};
+
+};
+
+PLAYGROUND.Pointer.plugin = true;
+
+PLAYGROUND.Pointer.prototype = {
+
+  updatePointer: function(pointer) {
+
+    this.pointers[pointer.id] = pointer;
+
+  },
+
+  removePointer: function(pointer) {
+
+    delete this.pointers[pointer.id];
+
+  },
+
+  touchstart: function(e) {
+
+    e.touch = true;
+
+    this.updatePointer(e);
+
+    this.app.emitGlobalEvent("pointerdown", e);
+
+  },
+
+  touchend: function(e) {
+
+    e.touch = true;
+
+    this.removePointer(e);
+
+    this.app.emitGlobalEvent("pointerup", e);
+
+  },
+
+  touchmove: function(e) {
+
+    e.touch = true;
+
+    this.updatePointer(e);
+
+    this.app.emitGlobalEvent("pointermove", e);
+
+  },
+
+  mousemove: function(e) {
+
+    e.mouse = true;
+
+    this.updatePointer(e);
+
+    this.app.emitGlobalEvent("pointermove", e);
+
+  },
+
+  mousedown: function(e) {
+
+    e.mouse = true;
+
+    this.app.emitGlobalEvent("pointerdown", e);
+
+  },
+
+  mouseup: function(e) {
+
+    e.mouse = true;
+
+    this.app.emitGlobalEvent("pointerup", e);
+
+  },
+
+  mousewheel: function(e) {
+
+    e.mouse = true;
+
+    this.app.emitGlobalEvent("pointerwheel", e);
+
+  }
+
+};
+
+/* file: src/Loader.js */
+
+/* Loader */
+
+PLAYGROUND.Loader = function(app) {
+
+  this.app = app;
+
+  PLAYGROUND.Events.call(this);
+
+  this.reset();
+
+};
+
+PLAYGROUND.Loader.prototype = {
+
+  /* loader */
+
+  add: function(id) {
+
+    this.queue++;
+    this.count++;
+    this.ready = false;
+    this.trigger("add", id);
+
+    return id;
+
+  },
+
+  error: function(id) {
+
+    this.trigger("error", id);
+
+  },
+
+  success: function(id) {
+
+    this.queue--;   
+
+    this.progress = 1 - this.queue / this.count;
+
+    this.trigger("load", id);
+
+    if (this.queue <= 0) {
+      this.reset();
+      this.trigger("ready");
+    }
+    
+  },
+
+  reset: function() {
+
+    this.progress = 0;
+    this.queue = 0;
+    this.count = 0;
+    this.ready = true;
+
+  }
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Loader.prototype, PLAYGROUND.Events.prototype);
+
+/* file: src/Mouse.js */
+
+PLAYGROUND.Mouse = function(app, element) {
+
+  var self = this;
+
+  this.app = app;
+
+  PLAYGROUND.Events.call(this);
+
+  this.element = element;
+
+  this.buttons = {};
+
+  this.preventContextMenu = true;
+
+  this.mousemoveEvent = {};
+  this.mousedownEvent = {};
+  this.mouseupEvent = {};
+  this.mousewheelEvent = {};
+
+  this.x = 0;
+  this.y = 0;
+
+  element.addEventListener("mousemove", this.mousemove.bind(this));
+  element.addEventListener("mousedown", this.mousedown.bind(this));
+  element.addEventListener("mouseup", this.mouseup.bind(this));
+
+  this.enableMousewheel();
+
+  this.element.addEventListener("contextmenu", function(e) {
+    if (self.preventContextMenu && !e.metaKey) e.preventDefault();
+  });
+
+  element.requestPointerLock = element.requestPointerLock ||
+    element.mozRequestPointerLock ||
+    element.webkitRequestPointerLock;
+
+  document.exitPointerLock = document.exitPointerLock ||
+    document.mozExitPointerLock ||
+    document.webkitExitPointerLock;
+
+
+  this.handleResize();
+};
+
+PLAYGROUND.Mouse.prototype = {
+
+  lock: function() {
+
+    this.locked = true;
+    this.element.requestPointerLock();
+
+  },
+
+  unlock: function() {
+
+    this.locked = false;
+    document.exitPointerLock();
+
+  },
+
+  getElementOffset: function(element) {
+
+    var offsetX = 0;
+    var offsetY = 0;
+
+    do {
+      offsetX += element.offsetLeft;
+      offsetY += element.offsetTop;
+    }
+
+    while ((element = element.offsetParent));
+
+    return {
+      x: offsetX,
+      y: offsetY
+    };
+
+  },
+
+  handleResize: function() {
+
+    this.elementOffset = this.getElementOffset(this.element);
+
+  },
+
+  mousemove: PLAYGROUND.Utils.throttle(function(e) {
+
+    this.x = this.mousemoveEvent.x = (e.pageX - this.elementOffset.x - this.app.offsetX) / this.app.scale | 0;
+    this.y = this.mousemoveEvent.y = (e.pageY - this.elementOffset.y - this.app.offsetY) / this.app.scale | 0;
+
+    this.mousemoveEvent.original = e;
+
+    if (this.locked) {
+      this.mousemoveEvent.movementX = e.movementX ||
+        e.mozMovementX ||
+        e.webkitMovementX ||
+        0;
+
+      this.mousemoveEvent.movementY = e.movementY ||
+        e.mozMovementY ||
+        e.webkitMovementY ||
+        0;
+    }
+
+    if (this.app.mouseToTouch) {
+      //      if (this.left) {
+      this.mousemoveEvent.id = this.mousemoveEvent.identifier = 255;
+      this.trigger("touchmove", this.mousemoveEvent);
+      //      }
+    } else {
+      this.mousemoveEvent.id = this.mousemoveEvent.identifier = 255;
+      this.trigger("mousemove", this.mousemoveEvent);
+    }
+
+  }, 16),
+
+  mousedown: function(e) {
+
+    var buttonName = ["left", "middle", "right"][e.button];
+
+    this.mousedownEvent.x = this.mousemoveEvent.x;
+    this.mousedownEvent.y = this.mousemoveEvent.y;
+    this.mousedownEvent.button = buttonName;
+    this.mousedownEvent.original = e;
+
+    this[buttonName] = true;
+
+    this.mousedownEvent.id = this.mousedownEvent.identifier = 255;
+
+    if (this.app.mouseToTouch) {
+      this.trigger("touchmove", this.mousedownEvent);
+      this.trigger("touchstart", this.mousedownEvent);
+    } else {
+      this.trigger("mousedown", this.mousedownEvent);
+    }
+
+  },
+
+  mouseup: function(e) {
+
+    var buttonName = ["left", "middle", "right"][e.button];
+
+    this.mouseupEvent.x = this.mousemoveEvent.x;
+    this.mouseupEvent.y = this.mousemoveEvent.y;
+    this.mouseupEvent.button = buttonName;
+    this.mouseupEvent.original = e;
+
+    this.mouseupEvent.id = this.mouseupEvent.identifier = 255;
+
+    if (this.app.mouseToTouch) {
+
+      this.trigger("touchend", this.mouseupEvent);
+
+    } else {
+
+      this.trigger("mouseup", this.mouseupEvent);
+
+    }
+
+    this[buttonName] = false;
+    
+  },
+
+  mousewheel: function(e) {
+
+    this.mousewheelEvent.x = this.mousemoveEvent.x;
+    this.mousewheelEvent.y = this.mousemoveEvent.y;
+    this.mousewheelEvent.button = ["none", "left", "middle", "right"][e.button];
+    this.mousewheelEvent.original = e;
+    this.mousewheelEvent.id = this.mousewheelEvent.identifier = 255;
+
+    this[e.button] = false;
+
+    this.trigger("mousewheel", this.mousewheelEvent);
+
+  },
+
+
+  enableMousewheel: function() {
+
+    var eventNames = 'onwheel' in document || document.documentMode >= 9 ? ['wheel'] : ['mousewheel', 'DomMouseScroll', 'MozMousePixelScroll'];
+    var callback = this.mousewheel.bind(this);
+    var self = this;
+
+    for (var i = eventNames.length; i;) {
+
+      self.element.addEventListener(eventNames[--i], PLAYGROUND.Utils.throttle(function(event) {
+
+        var orgEvent = event || window.event,
+          args = [].slice.call(arguments, 1),
+          delta = 0,
+          deltaX = 0,
+          deltaY = 0,
+          absDelta = 0,
+          absDeltaXY = 0,
+          fn;
+
+        orgEvent.type = "mousewheel";
+
+        // Old school scrollwheel delta
+        if (orgEvent.wheelDelta) {
+          delta = orgEvent.wheelDelta;
+        }
+
+        if (orgEvent.detail) {
+          delta = orgEvent.detail * -1;
+        }
+
+        // New school wheel delta (wheel event)
+        if (orgEvent.deltaY) {
+          deltaY = orgEvent.deltaY * -1;
+          delta = deltaY;
+        }
+
+        // Webkit
+        if (orgEvent.wheelDeltaY !== undefined) {
+          deltaY = orgEvent.wheelDeltaY;
+        }
+
+        var result = delta ? delta : deltaY;
+
+        self.mousewheelEvent.x = self.mousemoveEvent.x;
+        self.mousewheelEvent.y = self.mousemoveEvent.y;
+        self.mousewheelEvent.delta = result / Math.abs(result);
+        self.mousewheelEvent.original = orgEvent;
+
+        callback(self.mousewheelEvent);
+
+        orgEvent.preventDefault();
+
+      }, 40), false);
+    }
+
+  }
+
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Mouse.prototype, PLAYGROUND.Events.prototype);
+
+/* file: src/Sound.js */
+
+PLAYGROUND.Sound = function(app) {
+
+  var audioContext = window.AudioContext || window.webkitAudioContext || window.mozAudioContext;
+
+  if (audioContext) {
+
+    if (!PLAYGROUND.audioContext) PLAYGROUND.audioContext = new audioContext;
+
+    app.audioContext = PLAYGROUND.audioContext;
+    app.sound = new PLAYGROUND.SoundWebAudioAPI(app, app.audioContext);
+    app.music = new PLAYGROUND.SoundWebAudioAPI(app, app.audioContext);
+
+  } else {
+
+    app.sound = new PLAYGROUND.SoundAudio(app);
+    app.music = new PLAYGROUND.SoundAudio(app);
+
+  }
+
+};
+
+PLAYGROUND.Application.prototype.playSound = function(key, loop) {
+
+  return this.sound.play(key, loop);
+
+};
+
+PLAYGROUND.Application.prototype.stopSound = function(sound) {
+
+  this.sound.stop(sound);
+
+};
+
+PLAYGROUND.Application.prototype.loadSound = function() {
+
+  return this.loadSounds.apply(this, arguments);
+
+};
+
+PLAYGROUND.Application.prototype.loadSounds = function() {
+
+  for (var i = 0; i < arguments.length; i++) {
+
+    var arg = arguments[i];
+
+    /* polymorphism at its finest */
+
+    if (typeof arg === "object") {
+
+      for (var key in arg) this.loadSounds(arg[key]);
+
+    } else {
+      this.sound.load(arg);
+    }
+  }
+
+};
+
+/* file: src/SoundWebAudioAPI.js */
+
+PLAYGROUND.SoundWebAudioAPI = function(app, audioContext) {
+
+  this.app = app;
+
+  var canPlayMp3 = (new Audio).canPlayType("audio/mp3");
+  var canPlayOgg = (new Audio).canPlayType('audio/ogg; codecs="vorbis"');
+
+  if (this.app.preferedAudioFormat === "mp3") {
+
+    if (canPlayMp3) this.audioFormat = "mp3";
+    else this.audioFormat = "ogg";
+
+  } else {
+
+    if (canPlayOgg) this.audioFormat = "ogg";
+    else this.audioFormat = "mp3";
+
+  }
+
+  this.context = audioContext;
+
+  this.gainNode = this.context.createGain()
+  this.gainNode.connect(this.context.destination);
+
+  this.compressor = this.context.createDynamicsCompressor();
+  this.compressor.connect(this.gainNode);
+
+  this.output = this.gainNode;
+
+  this.gainNode.gain.value = 1.0;
+
+  this.pool = [];
+  this.volume = 1.0;
+
+  this.setMasterPosition(0, 0, 0);
+
+  this.loops = [];
+
+  this.app.on("step", this.step.bind(this));
+
+};
+
+PLAYGROUND.SoundWebAudioAPI.prototype = {
+
+  buffers: {},
+  aliases: {},
+
+  alias: function(alias, source, volume, rate) {
+
+    this.aliases[alias] = {
+      source: source,
+      volume: volume,
+      rate: rate
+    };
+
+  },
+
+  setMaster: function(volume) {
+
+    this.volume = volume;
+
+    this.gainNode.gain.value = volume;
+
+  },
+
+  load: function(file) {
+
+    var entry = this.app.getAssetEntry(file, "sounds", this.audioFormat);
+
+    var sampler = this;
+
+    var request = new XMLHttpRequest();
+
+    request.open("GET", entry.url, true);
+    request.responseType = "arraybuffer";
+
+    var id = this.app.loader.add(entry.url);
+
+    request.onload = function() {
+
+      sampler.context.decodeAudioData(this.response, function(decodedBuffer) {
+        sampler.buffers[entry.key] = decodedBuffer;
+        sampler.app.loader.success(entry.url);
+      });
+
+    }
+
+    request.send();
+
+  },
+
+  cleanArray: function(array, property) {
+    for (var i = 0, len = array.length; i < len; i++) {
+      if (array[i] === null || (property && array[i][property])) {
+        array.splice(i--, 1);
+        len--;
+      }
+    }
+  },
+
+  setMasterPosition: function(x, y, z) {
+
+    this.masterPosition = {
+      x: x,
+      y: y,
+      z: z
+    };
+
+    this.context.listener.setPosition(x, y, z)
+      // this.context.listener.setOrientation(0, 0, -1, 0, 1, 0);
+      // this.context.listener.dopplerFactor = 1;
+      // this.context.listener.speedOfSound = 343.3;
+  },
+
+  getSoundBuffer: function() {
+    if (!this.pool.length) {
+      for (var i = 0; i < 100; i++) {
+
+        var buffer, gain, panner;
+
+        var nodes = [
+          buffer = this.context.createBufferSource(),
+          gain = this.context.createGain(),
+          panner = this.context.createPanner()
+        ];
+
+        panner.distanceModel = "linear";
+
+        // 1 - rolloffFactor * (distance - refDistance) / (maxDistance - refDistance)
+        // refDistance / (refDistance + rolloffFactor * (distance - refDistance))
+        panner.refDistance = 1;
+        panner.maxDistance = 600;
+        panner.rolloffFactor = 1.0;
+
+
+        // panner.setOrientation(-1, -1, 0);
+
+        this.pool.push(nodes);
+
+        nodes[0].connect(nodes[1]);
+        // nodes[1].connect(nodes[2]);
+        nodes[1].connect(this.output);
+      }
+    }
+
+    return this.pool.pop();
+  },
+
+  play: function(name, loop) {
+
+    var alias = this.aliases[name];
+
+    var nodes = this.getSoundBuffer();
+
+    if (alias) name = alias.source;
+
+    bufferSource = nodes[0];
+    bufferSource.gainNode = nodes[1];
+    bufferSource.pannerNode = nodes[2];
+    bufferSource.buffer = this.buffers[name];
+    bufferSource.loop = loop || false;
+    bufferSource.key = name;
+
+    bufferSource.alias = alias;
+
+    this.setVolume(bufferSource, 1.0);
+    this.setPlaybackRate(bufferSource, 1.0);
+
+    if (this.loop) {
+      //  bufferSource.loopStart = this.loopStart;
+      // bufferSource.loopEnd = this.loopEnd;
+    }
+
+
+    bufferSource.start(0);
+
+    bufferSource.volumeLimit = 1;
+
+    this.setPosition(bufferSource, this.masterPosition.x, this.masterPosition.y, this.masterPosition.z);
+
+    return bufferSource;
+  },
+
+  stop: function(what) {
+
+    if (!what) return;
+
+    what.stop(0);
+
+  },
+
+  setPlaybackRate: function(sound, rate) {
+
+    if (!sound) return;
+
+    if (sound.alias) rate *= sound.alias.rate;
+
+    return sound.playbackRate.value = rate;
+  },
+
+  setPosition: function(sound, x, y, z) {
+
+    if (!sound) return;
+
+    sound.pannerNode.setPosition(x, y || 0, z || 0);
+  },
+
+  setVelocity: function(sound, x, y, z) {
+
+    if (!sound) return;
+
+    sound.pannerNode.setPosition(x, y || 0, z || 0);
+
+  },
+
+  getVolume: function(sound) {
+
+    if (!sound) return;
+
+    return sound.gainNode.gain.value;
+
+  },
+
+  setVolume: function(sound, volume) {
+
+    if (!sound) return;
+
+    if (sound.alias) volume *= sound.alias.volume;
+
+    return sound.gainNode.gain.value = Math.max(0, volume);
+  },
+
+  fadeOut: function(sound) {
+
+    if (!sound) return;
+
+    sound.fadeOut = true;
+
+    this.loops.push(sound);
+
+    return sound;
+
+  },
+
+  fadeIn: function(sound) {
+
+    if (!sound) return;
+
+    sound.fadeIn = true;
+
+    this.loops.push(sound);
+    this.setVolume(sound, 0);
+
+
+    return sound;
+
+  },
+
+  step: function(delta) {
+
+    for (var i = 0; i < this.loops.length; i++) {
+
+      var loop = this.loops[i];
+
+      if (loop.fadeIn) {
+        var volume = this.getVolume(loop);
+        volume = this.setVolume(loop, Math.min(1.0, volume + delta * 0.5));
+
+        if (volume >= 1.0) {
+          this.loops.splice(i--, 1);
+        }
+      }
+
+      if (loop.fadeOut) {
+        var volume = this.getVolume(loop);
+        volume = this.setVolume(loop, Math.min(1.0, volume - delta * 0.5));
+
+        if (volume <= 0) {
+          this.loops.splice(i--, 1);
+          this.stop(loop);
+        }
+      }
+
+    }
+
+  }
+
+};
+
+/* file: src/SoundAudio.js */
+
+PLAYGROUND.SoundAudio = function(app) {
+
+  this.app = app;  
+
+  var canPlayMp3 = (new Audio).canPlayType("audio/mp3");
+  var canPlayOgg = (new Audio).canPlayType('audio/ogg; codecs="vorbis"');
+
+  if (this.app.preferedAudioFormat === "mp3") {
+
+    if (canPlayMp3) this.audioFormat = "mp3";
+    else this.audioFormat = "ogg";
+
+  } else {
+
+    if (canPlayOgg) this.audioFormat = "ogg";
+    else this.audioFormat = "mp3";
+
+  }
+
+};
+
+PLAYGROUND.SoundAudio.prototype = {
+
+  samples: {},
+
+  setMaster: function(volume) {
+
+    this.volume = volume;
+
+  },
+
+  setMasterPosition: function() {
+
+  },
+
+  setPosition: function(x, y, z) {
+    return;
+  },
+
+  load: function(file) {
+
+    var url = "sounds/" + file + "." + this.audioFormat;
+
+    var loader = this.app.loader;
+
+    this.app.loader.add(url);
+
+    var audio = this.samples[file] = new Audio;
+
+    audio.addEventListener("canplay", function() {
+      loader.success(url);
+    });
+
+    audio.addEventListener("error", function() {
+      loader.error(url);
+    });
+
+    audio.src = url;
+
+  },
+
+  play: function(key, loop) {
+
+    var sound = this.samples[key];
+
+    sound.currentTime = 0;
+    sound.loop = loop;
+    sound.play();
+
+    return sound;
+
+  },
+
+  stop: function(what) {
+
+    if (!what) return;
+
+    what.pause();
+
+  },
+
+  step: function(delta) {
+
+  },
+
+  setPlaybackRate: function(sound, rate) {
+
+    return;
+  },
+
+  setVolume: function(sound, volume) {
+
+    sound.volume = volume * this.volume;
+
+  },
+
+  setPosition: function() {
+
+  }
+
+};
+
+/* file: src/Touch.js */
+
+PLAYGROUND.Touch = function(app, element) {
+
+  PLAYGROUND.Events.call(this);
+
+  this.app = app;
+
+  this.element = element;
+
+  this.buttons = {};
+
+  this.touches = {};
+
+  this.x = 0;
+  this.y = 0;
+
+  element.addEventListener("touchmove", this.touchmove.bind(this));
+  element.addEventListener("touchstart", this.touchstart.bind(this));
+  element.addEventListener("touchend", this.touchend.bind(this));
+
+};
+
+PLAYGROUND.Touch.prototype = {
+
+  getElementOffset: function(element) {
+
+    var offsetX = 0;
+    var offsetY = 0;
+
+    do {
+      offsetX += element.offsetLeft;
+      offsetY += element.offsetTop;
+    }
+
+    while ((element = element.offsetParent));
+
+    return {
+      x: offsetX,
+      y: offsetY
+    };
+
+  },
+
+  handleResize: function() {
+
+    this.elementOffset = this.getElementOffset(this.element);
+
+  },
+
+  touchmove: function(e) {
+
+    for (var i = 0; i < e.changedTouches.length; i++) {
+
+      var touch = e.changedTouches[i];
+
+      touchmoveEvent = {}
+
+      this.x = touchmoveEvent.x = (touch.pageX - this.elementOffset.x - this.app.offsetX) / this.app.scale | 0;
+      this.y = touchmoveEvent.y = (touch.pageY - this.elementOffset.y - this.app.offsetY) / this.app.scale | 0;
+
+      touchmoveEvent.original = touch;
+      touchmoveEvent.id = touchmoveEvent.identifier = touch.identifier;
+
+      this.touches[touch.identifier].x = touchmoveEvent.x;
+      this.touches[touch.identifier].y = touchmoveEvent.y;
+
+      this.trigger("touchmove", touchmoveEvent);
+
+    }
+
+    e.preventDefault();
+
+  },
+
+  touchstart: function(e) {
+
+    for (var i = 0; i < e.changedTouches.length; i++) {
+
+      var touch = e.changedTouches[i];
+
+      var touchstartEvent = {}
+
+      this.x = touchstartEvent.x = (touch.pageX - this.elementOffset.x - this.app.offsetX) / this.app.scale | 0;
+      this.y = touchstartEvent.y = (touch.pageY - this.elementOffset.y - this.app.offsetY) / this.app.scale | 0;
+
+      touchstartEvent.original = e.touch;
+      touchstartEvent.id = touchstartEvent.identifier = touch.identifier;
+
+      this.touches[touch.identifier] = {
+        x: touchstartEvent.x,
+        y: touchstartEvent.y
+      };
+
+      this.trigger("touchstart", touchstartEvent);
+
+    }
+
+    e.preventDefault();
+
+  },
+
+  touchend: function(e) {
+
+    for (var i = 0; i < e.changedTouches.length; i++) {
+
+      var touch = e.changedTouches[i];
+      var touchendEvent = {};
+
+      touchendEvent.x = (touch.pageX - this.elementOffset.x - this.app.offsetX) / this.app.scale | 0;
+      touchendEvent.y = (touch.pageY - this.elementOffset.y - this.app.offsetY) / this.app.scale | 0;
+
+      touchendEvent.original = touch;
+      touchendEvent.id = touchendEvent.identifier = touch.identifier;
+
+      delete this.touches[touch.identifier];
+
+      this.trigger("touchend", touchendEvent);
+
+    }
+
+    e.preventDefault();
+
+  }
+
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Touch.prototype, PLAYGROUND.Events.prototype);
+
+/* file: src/Tween.js */
+
+PLAYGROUND.Tween = function(manager, context) {
+
+  PLAYGROUND.Events.call(this);
+
+  this.manager = manager;
+  this.context = context;
+
+  PLAYGROUND.Utils.extend(this, {
+
+    actions: [],
+    index: -1,
+
+    prevEasing: "045",
+    prevDuration: 0.5
+
+  });
+
+  this.current = false;
+
+};
+
+PLAYGROUND.Tween.prototype = {
+
+  add: function(properties, duration, easing) {
+
+    if (duration) this.prevDuration = duration;
+    else duration = 0.5;
+    if (easing) this.prevEasing = easing;
+    else easing = "045";
+
+    this.actions.push([properties, duration, easing]);
+
+    return this;
+
+  },
+
+  discard: function() {
+
+    this.manager.discard(this.context, this);
+
+    return this;
+
+  },
+
+  to: function(properties, duration, easing) {
+    return this.add(properties, duration, easing);
+  },
+
+  loop: function() {
+
+    this.looped = true;
+
+    return this;
+
+  },
+
+  repeat: function(times) {
+
+    this.actions.push(["repeat", times]);
+
+  },
+
+  wait: function(time) {
+
+    this.actions.push(["wait", time]);
+
+    return this;
+
+  },
+
+  delay: function(time) {
+
+    this.actions.push(["wait", time]);
+
+  },
+
+  stop: function() {
+
+    this.manager.remove(this);
+
+    return this;
+
+  },
+
+  play: function() {
+
+    this.manager.add(this);
+
+    this.finished = false;
+
+    return this;
+
+  },
+
+
+  end: function() {
+
+    var lastAnimationIndex = 0;
+
+    for (var i = this.index + 1; i < this.actions.length; i++) {
+      if (typeof this.actions[i][0] === "object") lastAnimationIndex = i;
+    }
+
+    this.index = lastAnimationIndex - 1;
+    this.next();
+    this.delta = this.duration;
+    this.step(0);
+
+    return this;
+
+  },
+
+  forward: function() {
+
+    this.delta = this.duration;
+    this.step(0);
+
+  },
+
+  rewind: function() {
+
+    this.delta = 0;
+    this.step(0);
+
+  },
+
+  next: function() {
+
+    this.delta = 0;
+
+    this.index++;
+
+    if (this.index >= this.actions.length) {
+
+      if (this.looped) {
+
+        this.trigger("loop", {
+          tween: this
+        });
+
+        this.index = 0;
+      } else {
+
+        this.trigger("finished", {
+          tween: this
+        });
+
+        this.finished = true;
+        this.manager.remove(this);
+        return;
+      }
+    }
+
+    this.current = this.actions[this.index];
+
+    if (this.current[0] === "wait") {
+
+      this.duration = this.current[1];
+      this.currentAction = "wait";
+
+    } else {
+
+      /* calculate changes */
+
+      var properties = this.current[0];
+
+      /* keep keys as array for 0.0001% performance boost */
+
+      this.keys = Object.keys(properties);
+
+      this.change = [];
+      this.before = [];
+      this.types = [];
+
+      for (i = 0; i < this.keys.length; i++) {
+        var key = this.keys[i];
+
+        if (typeof this.context[key] === "number") {
+          this.before.push(this.context[key]);
+          this.change.push(properties[key] - this.context[key]);
+          this.types.push(0);
+        } else {
+          var before = cq.color(this.context[key]);
+
+          this.before.push(before);
+
+          var after = cq.color(properties[key]);
+
+          var temp = [];
+
+          for (var j = 0; j < 3; j++) {
+            temp.push(after[j] - before[j]);
+          }
+
+          this.change.push(temp);
+
+          this.types.push(1);
+        }
+
+      }
+
+      this.currentAction = "animate";
+
+      this.duration = this.current[1];
+      this.easing = this.current[2];
+
+    }
+
+
+  },
+
+  prev: function() {
+
+  },
+
+  step: function(delta) {
+
+    this.delta += delta;
+
+    if (!this.current) this.next();
+
+    switch (this.currentAction) {
+
+      case "animate":
+        this.doAnimate(delta);
+        break;
+
+      case "wait":
+        this.doWait(delta);
+        break;
+
+    }
+
+  },
+
+  doAnimate: function(delta) {
+
+    this.progress = Math.min(1, this.delta / this.duration);
+
+    var mod = PLAYGROUND.Utils.ease(this.progress, this.easing);
+
+    for (var i = 0; i < this.keys.length; i++) {
+
+      var key = this.keys[i];
+
+      switch (this.types[i]) {
+
+        /* number */
+
+        case 0:
+
+          this.context[key] = this.before[i] + this.change[i] * mod;
+
+          break;
+
+          /* color */
+
+        case 1:
+
+          var change = this.change[i];
+          var before = this.before[i];
+          var color = [];
+
+          for (var j = 0; j < 3; j++) {
+            color.push(before[j] + change[j] * mod | 0);
+          }
+
+          this.context[key] = "rgb(" + color.join(",") + ")";
+
+          break;
+      }
+    }
+
+    if (this.progress >= 1) {
+      this.next();
+    }
+
+  },
+
+  doWait: function(delta) {
+
+    if (this.delta >= this.duration) this.next();
+
+  }
+
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Tween.prototype, PLAYGROUND.Events.prototype);
+
+PLAYGROUND.TweenManager = function(app) {
+
+  this.tweens = [];
+
+  if (app) {
+    this.app = app;
+    this.app.tween = this.tween.bind(this);
+  }
+
+  this.delta = 0;
+
+  this.app.on("step", this.step.bind(this));
+
+};
+
+PLAYGROUND.TweenManager.prototype = {
+
+  defaultEasing: "128",
+
+  discard: function(object, safe) {
+
+    for (var i = 0; i < this.tweens.length; i++) {
+      
+      var tween = this.tweens[i];
+
+      if(tween.context === object && tween !== safe) this.remove(tween);
+
+    }
+
+  },
+
+  tween: function(context) {
+
+    var tween = new PLAYGROUND.Tween(this, context);
+
+    this.add(tween);
+
+    return tween;
+
+  },
+ 
+  step: function(delta) {
+
+    this.delta += delta;
+
+    for (var i = 0; i < this.tweens.length; i++) {
+
+      var tween = this.tweens[i];
+
+      if (!tween._remove) tween.step(delta);
+      
+      if (tween._remove) this.tweens.splice(i--, 1);
+
+    }
+     
+  },
+
+  add: function(tween) {
+
+    tween._remove = false;
+
+    var index = this.tweens.indexOf(tween);
+
+    if (index === -1) this.tweens.push(tween);
+
+  },
+
+  remove: function(tween) {
+
+    tween._remove = true;
+
+  }
+
+};
+
+/* file: src/Atlases.js */
+
+PLAYGROUND.Application.prototype.loadAtlases = function() {
+
+  for (var i = 0; i < arguments.length; i++) {
+
+    var arg = arguments[i];
+
+    /* polymorphism at its finest */
+
+    if (typeof arg === "object") {
+
+      for (var key in arg) this.loadAtlases(arg[key]);
+
+    } else {
+
+      /* if argument is not an object/array let's try to load it */
+
+      this._loadAtlas(arg)
+
+    }
+  }
+
+};
+
+PLAYGROUND.Application.prototype.loadAtlas = function() {
+
+  return this.loadAtlases.apply(this, arguments);
+
+};
+
+PLAYGROUND.Application.prototype._loadAtlas = function(filename) {
+
+  var entry = this.getAssetEntry(filename, "atlases", "png");
+
+  this.loader.add(entry.url);
+
+  var atlas = this.atlases[entry.key] = {};
+
+  var image = atlas.image = new Image;
+
+  image.addEventListener("load", function() {
+    loader.success(entry.url);
+  });
+
+  image.addEventListener("error", function() {
+    loader.error(entry.url);
+  });
+
+  image.src = entry.url;
+
+  /* data */
+
+  var request = new XMLHttpRequest();
+
+  request.open("GET", entry.path + ".json", true);
+
+  this.loader.add(entry.path + ".json");
+
+  var loader = this.loader;
+
+  request.onload = function() {
+
+    var data = JSON.parse(this.response);
+
+    atlas.frames = [];
+
+    for (var i = 0; i < data.frames.length; i++) {
+      var frame = data.frames[i];
+
+      atlas.frames.push({
+        region: [frame.frame.x, frame.frame.y, frame.frame.w, frame.frame.h],
+        offset: [frame.spriteSourceSize.x || 0, frame.spriteSourceSize.y || 0],
+        width: frame.sourceSize.w,
+        height: frame.sourceSize.h
+      });
+    }
+
+    loader.success(entry.path + ".json");
+
+  }
+
+  request.send();
+};
+
+/* file: src/Fonts.js */
+
+PLAYGROUND.Application.prototype.loadFontOld = function(name) {
+
+  var styleNode = document.createElement("style");
+  styleNode.type = "text/css";
+
+  var formats = {
+    "woff": "woff",
+    "ttf": "truetype"
+  };
+
+  var sources = "";
+
+  for (var ext in formats) {
+    var type = formats[ext];
+    sources += " url(\"fonts/" + name + "." + ext + "\") format('" + type + "');"
+  }
+
+  styleNode.textContent = "@font-face { font-family: '" + name + "'; src: " + sources + " }";
+
+  document.head.appendChild(styleNode);
+
+  var layer = cq(32, 32);
+
+  layer.font("10px Testing");
+  layer.fillText(16, 16, 16).trim();
+
+  var width = layer.width;
+  var height = layer.height;
+
+  this.loader.add("font " + name);
+
+  var self = this;
+
+  function check() {
+
+    var layer = cq(32, 32);
+
+    layer.font("10px " + name).fillText(16, 16, 16);
+    layer.trim();
+
+    if (layer.width !== width || layer.height !== height) {
+
+      self.loader.ready("font " + name);
+
+    } else {
+
+      setTimeout(check, 250);
+
+    }
+
+  };
+
+  check();
+
+};
+
+/* file: src/DefaultState.js */
+
+PLAYGROUND.DefaultState = {
+
+};
+
+/* file: src/LoadingScreen.js */
+
+PLAYGROUND.LoadingScreen = {
+
+  /* basic loading screen using DOM */
+
+  logoRaw: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANoAAAASBAMAAADPiN0xAAAAGFBMVEUAAQAtLixHSUdnaGaJioimqKXMzsv7/fr5shgVAAAAAWJLR0QAiAUdSAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB98EAwkeA4oQWJ4AAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAB9klEQVQ4y72UvW+rMBDAz+FrpVKrrFmesmapWNOlrKjSe1kZ+uoVAvj+/frujG1SaJcqJwU7voOf7xMQzQmsIDi5NPTMsLRntH3U+F6SAZo3NlCvcgBFJz8o+vkDiE63lI95Y/UmpinsZWkgJWJiDbAVQ16htptxSTNloIlugwaw001Ey3ASF3so6L1qLNXzQS5S0UGKL/CI5wWNriE0UH9Yty37LqIVg+wsqu7Ix0MwVBSF/dU+jv2SNnma021LEdPqVnMeU3xAu0kXcSGjmq7Ox4E2Wn88LZ2+EFj3avjixzai6VPVyuYveZLHF2XfdDnvAq27DIHGuq+0DJFsE30OtB1KqOwd8Dr7PcM4b+jfj2g5lp4WyntBK66qua3JzEA+uXJpwH/NlVuzRVPY/kTLB2mjuN+KwdZ8FOy8j2gDbEUSqumnSCY4lf4ibq3IhVM4ycZQRnv+zFqVdJQVn6BxvUqebGpuaNo3sZxwBzjajiMZOoBiwyVF+kCr+nUaJOaGpnAeRPPJZTr4FqmHRXcneEo4DqQ/ftfdnLeDrUAME8xWKPeKCwW6YkEpXfs3p1EWJhdcUAYP0TI/uYaV8cgjwBovaeyWwji2T9rTFIdS/cP/MnkTLRUWxgNNZVin7bT5fqT9miDcUVJzR1gRpfIONMmulU+5Qqr6zXAUqAAAAABJRU5ErkJggg==",
+
+  create: function() {
+
+    var self = this;
+
+    this.logo = new Image;
+
+    this.logo.addEventListener("load", function() {
+      self.ready = true;
+      self.createElements();
+    });
+
+    this.logo.src = this.logoRaw;
+
+    this.background = "#000";
+
+    if (window.getComputedStyle) {
+      this.background = window.getComputedStyle(document.body).backgroundColor || "#000";
+    }
+
+
+  },
+
+  enter: function() {
+
+    this.current = 0;
+
+  },
+
+  leave: function() {
+
+    this.locked = true;
+
+    this.animation = this.app.tween(this)
+      .to({
+        current: 1
+      }, 0.5);
+
+  },
+
+  step: function(delta) {
+
+    if (this.locked) {
+
+      if (this.animation.finished) {
+        this.locked = false;
+        this.wrapper.parentNode.removeChild(this.wrapper);
+      }
+
+    } else {
+
+      this.current = this.current + Math.abs(this.app.loader.progress - this.current) * delta;
+    }
+
+  },
+
+  createElements: function() {
+
+    this.width = window.innerWidth * 0.6 | 0;
+    this.height = window.innerHeight * 0.1 | 0;
+
+    this.wrapper = document.createElement("div");
+    this.wrapper.style.width = this.width + "px";
+    this.wrapper.style.height = this.height + "px";
+    this.wrapper.style.background = "#000";
+    this.wrapper.style.border = "4px solid #fff";
+    this.wrapper.style.position = "absolute";
+    this.wrapper.style.left = (window.innerWidth / 2 - this.width / 2 | 0) + "px";
+    this.wrapper.style.top = (window.innerHeight / 2 - this.height / 2 | 0) + "px";
+    this.wrapper.style.zIndex = 100;
+
+    this.app.container.appendChild(this.wrapper);
+
+    this.progressBar = document.createElement("div");
+    this.progressBar.style.width = "0%";
+    this.progressBar.style.height = this.height + "px";
+    this.progressBar.style.background = "#fff";
+
+    this.wrapper.appendChild(this.progressBar);
+
+  },
+
+
+  render: function() {
+
+    if (!this.ready) return;
+
+    this.progressBar.style.width = (this.current * 100 | 0) + "%";
+
+
+  }
+
+};
+module.exports = playground;playground.Application = PLAYGROUND.Application;

--- a/build/commonjs/playground.js
+++ b/build/commonjs/playground.js
@@ -1,0 +1,5761 @@
+var PLAYGROUND;
+
+
+/* file: license.txt */
+
+/*     
+
+  PlaygroundJS r5
+  
+  http://playgroundjs.com
+  
+  (c) 2012-2015 http://rezoner.net
+  
+  Playground may be freely distributed under the MIT license.
+
+  latest major changes:
+
+  r5
+
+  + game loop nicely split into render and step - check profiler
+  + fixed loader last item
+  + fixed some flow issues
+  + imageready event
+  + loadFont
+  + gamepad stick issue
+  + pointerwheel event
+  + updated CanvasQuery
+  - removed video recorder  
+
+  r4
+
+  + tweens with events
+  + context argument for events
+
+  r3
+
+  + pointer = mouse + touch
+
+*/
+
+
+/* file: src/lib/Ease.js */
+
+/*     
+
+  Ease 1.0
+  
+  http://canvasquery.com
+  
+  (c) 2015 by Rezoner - http://rezoner.net
+
+  `ease` may be freely distributed under the MIT license.
+
+*/
+
+(function() {
+
+  var ease = function(progress, easing) {
+
+    if (typeof ease.cache[easing] === "function") {
+
+      return ease.cache[easing](progress);
+
+    } else {
+
+      return ease.spline(progress, easing || ease.defaultEasing);
+
+    }
+
+  };
+
+  var extend = function() {
+    for (var i = 1; i < arguments.length; i++) {
+      for (var j in arguments[i]) {
+        arguments[0][j] = arguments[i][j];
+      }
+    }
+
+    return arguments[0];
+  };
+
+  extend(ease, {
+
+    defaultEasing: "016",
+
+    cache: {
+
+      linear: function(t) {
+        return t
+      },
+
+      inQuad: function(t) {
+        return t * t
+      },
+      outQuad: function(t) {
+        return t * (2 - t)
+      },
+      inOutQuad: function(t) {
+        return t < .5 ? 2 * t * t : -1 + (4 - 2 * t) * t
+      },
+      inCubic: function(t) {
+        return t * t * t
+      },
+      outCubic: function(t) {
+        return (--t) * t * t + 1
+      },
+      inOutCubic: function(t) {
+        return t < .5 ? 4 * t * t * t : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1
+      },
+      inQuart: function(t) {
+        return t * t * t * t
+      },
+      outQuart: function(t) {
+        return 1 - (--t) * t * t * t
+      },
+      inOutQuart: function(t) {
+        return t < .5 ? 8 * t * t * t * t : 1 - 8 * (--t) * t * t * t
+      },
+      inQuint: function(t) {
+        return t * t * t * t * t
+      },
+      outQuint: function(t) {
+        return 1 + (--t) * t * t * t * t
+      },
+      inOutQuint: function(t) {
+        return t < .5 ? 16 * t * t * t * t * t : 1 + 16 * (--t) * t * t * t * t
+      },
+      inSine: function(t) {
+        return -1 * Math.cos(t / 1 * (Math.PI * 0.5)) + 1;
+      },
+      outSine: function(t) {
+        return Math.sin(t / 1 * (Math.PI * 0.5));
+      },
+      inOutSine: function(t) {
+        return -1 / 2 * (Math.cos(Math.PI * t) - 1);
+      },
+      inExpo: function(t) {
+        return (t == 0) ? 0 : Math.pow(2, 10 * (t - 1));
+      },
+      outExpo: function(t) {
+        return (t == 1) ? 1 : (-Math.pow(2, -10 * t) + 1);
+      },
+      inOutExpo: function(t) {
+        if (t == 0) return 0;
+        if (t == 1) return 1;
+        if ((t /= 1 / 2) < 1) return 1 / 2 * Math.pow(2, 10 * (t - 1));
+        return 1 / 2 * (-Math.pow(2, -10 * --t) + 2);
+      },
+      inCirc: function(t) {
+        return -1 * (Math.sqrt(1 - t * t) - 1);
+      },
+      outCirc: function(t) {
+        return Math.sqrt(1 - (t = t - 1) * t);
+      },
+      inOutCirc: function(t) {
+        if ((t /= 1 / 2) < 1) return -1 / 2 * (Math.sqrt(1 - t * t) - 1);
+        return 1 / 2 * (Math.sqrt(1 - (t -= 2) * t) + 1);
+      },
+      inElastic: function(t) {
+        var s = 1.70158;
+        var p = 0;
+        var a = 1;
+        if (t == 0) return 0;
+        if (t == 1) return 1;
+        if (!p) p = 0.3;
+        if (a < 1) {
+          a = 1;
+          var s = p / 4;
+        } else var s = p / (2 * Math.PI) * Math.asin(1 / a);
+        return -(a * Math.pow(2, 10 * (t -= 1)) * Math.sin((t - s) * (2 * Math.PI) / p));
+      },
+      outElastic: function(t) {
+        var s = 1.70158;
+        var p = 0;
+        var a = 1;
+        if (t == 0) return 0;
+        if (t == 1) return 1;
+        if (!p) p = 0.3;
+        if (a < 1) {
+          a = 1;
+          var s = p / 4;
+        } else var s = p / (2 * Math.PI) * Math.asin(1 / a);
+        return a * Math.pow(2, -10 * t) * Math.sin((t - s) * (2 * Math.PI) / p) + 1;
+      },
+      inOutElastic: function(t) {
+        var s = 1.70158;
+        var p = 0;
+        var a = 1;
+        if (t == 0) return 0;
+        if ((t /= 1 / 2) == 2) return 1;
+        if (!p) p = (0.3 * 1.5);
+        if (a < 1) {
+          a = 1;
+          var s = p / 4;
+        } else var s = p / (2 * Math.PI) * Math.asin(1 / a);
+        if (t < 1) return -.5 * (a * Math.pow(2, 10 * (t -= 1)) * Math.sin((t - s) * (2 * Math.PI) / p));
+        return a * Math.pow(2, -10 * (t -= 1)) * Math.sin((t - s) * (2 * Math.PI) / p) * 0.5 + 1;
+      },
+      inBack: function(t, s) {
+        if (s == undefined) s = 1.70158;
+        return 1 * t * t * ((s + 1) * t - s);
+      },
+      outBack: function(t, s) {
+        if (s == undefined) s = 1.70158;
+        return 1 * ((t = t / 1 - 1) * t * ((s + 1) * t + s) + 1);
+      },
+      inOutBack: function(t, s) {
+        if (s == undefined) s = 1.70158;
+        if ((t /= 1 / 2) < 1) return 1 / 2 * (t * t * (((s *= (1.525)) + 1) * t - s));
+        return 1 / 2 * ((t -= 2) * t * (((s *= (1.525)) + 1) * t + s) + 2);
+      },
+      inBounce: function(t) {
+        return 1 - this.outBounce(1 - t);
+      },
+      outBounce: function(t) {
+        if ((t /= 1) < (1 / 2.75)) {
+          return (7.5625 * t * t);
+        } else if (t < (2 / 2.75)) {
+          return (7.5625 * (t -= (1.5 / 2.75)) * t + .75);
+        } else if (t < (2.5 / 2.75)) {
+          return (7.5625 * (t -= (2.25 / 2.75)) * t + .9375);
+        } else {
+          return (7.5625 * (t -= (2.625 / 2.75)) * t + .984375);
+        }
+      },
+      inOutBounce: function(t) {
+        if (t < 1 / 2) return this.inBounce(t * 2) * 0.5;
+        return this.outBounce(t * 2 - 1) * 0.5 + 0.5;
+      }
+    },
+
+    translateEasing: function(key) {
+
+      if (!this.cache[key]) {
+        var array = key.split('');
+
+        var sign = 1;
+        var signed = false;
+
+        for (var i = 0; i < array.length; i++) {
+
+          var char = array[i];
+
+          if (char === "-") {
+            sign = -1;
+            signed = true;
+            array.splice(i--, 1);
+          } else if (char === "+") {
+            sign = 1;
+            array.splice(i--, 1);
+          } else array[i] = parseInt(array[i], 16) * sign;
+
+        }
+
+        var min = Math.min.apply(null, array);
+        var max = Math.max.apply(null, array);
+        var diff = max - min;
+        var cache = [];
+        var normalized = [];
+
+        for (var i = 0; i < array.length; i++) {
+          if (signed) {
+            var diff = Math.max(Math.abs(min), Math.abs(max))
+            normalized.push((array[i]) / diff);
+          } else {
+            var diff = max - min;
+            normalized.push((array[i] - min) / diff);
+          }
+        }
+
+        this.cache[key] = normalized;
+
+      }
+
+      return this.cache[key]
+
+    },
+
+    /* 
+      
+      Cubic-spline interpolation by Ivan Kuckir
+
+      http://blog.ivank.net/interpolation-with-cubic-splines.html
+
+      With slight modifications by Morgan Herlocker
+
+      https://github.com/morganherlocker/cubic-spline
+
+    */
+
+    splineK: {},
+    splineX: {},
+    splineY: {},
+
+    insertIntermediateValues: function(a) {
+      var result = [];
+      for (var i = 0; i < a.length; i++) {
+        result.push(a[i]);
+
+        if (i < a.length - 1) result.push(a[i + 1] + (a[i] - a[i + 1]) * 0.6);
+      }
+
+      return result;
+    },
+
+    spline: function(x, key) {
+
+      if (!this.splineK[key]) {
+
+        var xs = [];
+        var ys = this.translateEasing(key);
+
+        // ys = this.insertIntermediateValues(ys);
+
+        if (!ys.length) return 0;
+
+        for (var i = 0; i < ys.length; i++) xs.push(i * (1 / (ys.length - 1)));
+
+        var ks = xs.map(function() {
+          return 0
+        });
+
+        ks = this.getNaturalKs(xs, ys, ks);
+
+        this.splineX[key] = xs;
+        this.splineY[key] = ys;
+        this.splineK[key] = ks;
+
+      }
+
+      if (x > 1) return this.splineY[key][this.splineY[key].length - 1];
+
+      var ks = this.splineK[key];
+      var xs = this.splineX[key];
+      var ys = this.splineY[key];
+
+      var i = 1;
+
+      while (xs[i] < x) i++;
+
+      var t = (x - xs[i - 1]) / (xs[i] - xs[i - 1]);
+      var a = ks[i - 1] * (xs[i] - xs[i - 1]) - (ys[i] - ys[i - 1]);
+      var b = -ks[i] * (xs[i] - xs[i - 1]) + (ys[i] - ys[i - 1]);
+      var q = (1 - t) * ys[i - 1] + t * ys[i] + t * (1 - t) * (a * (1 - t) + b * t);
+
+      /*
+      var py = ys[i - 2];
+      var cy = ys[i - 1];
+      var ny = (i < ys.length - 1) ? ys[i] : ys[i - 1];
+
+      if (q > ny) {
+        var diff = (q - py);
+        //q = py + diff;
+
+      }
+
+    if (cy === ny && cy === py) q = py;
+    */
+
+
+      return q;
+    },
+
+    getNaturalKs: function(xs, ys, ks) {
+      var n = xs.length - 1;
+      var A = this.zerosMat(n + 1, n + 2);
+
+      for (var i = 1; i < n; i++) // rows
+      {
+        A[i][i - 1] = 1 / (xs[i] - xs[i - 1]);
+        A[i][i] = 2 * (1 / (xs[i] - xs[i - 1]) + 1 / (xs[i + 1] - xs[i]));
+        A[i][i + 1] = 1 / (xs[i + 1] - xs[i]);
+        A[i][n + 1] = 3 * ((ys[i] - ys[i - 1]) / ((xs[i] - xs[i - 1]) * (xs[i] - xs[i - 1])) + (ys[i + 1] - ys[i]) / ((xs[i + 1] - xs[i]) * (xs[i + 1] - xs[i])));
+      }
+
+      A[0][0] = 2 / (xs[1] - xs[0]);
+      A[0][1] = 1 / (xs[1] - xs[0]);
+      A[0][n + 1] = 3 * (ys[1] - ys[0]) / ((xs[1] - xs[0]) * (xs[1] - xs[0]));
+
+      A[n][n - 1] = 1 / (xs[n] - xs[n - 1]);
+      A[n][n] = 2 / (xs[n] - xs[n - 1]);
+      A[n][n + 1] = 3 * (ys[n] - ys[n - 1]) / ((xs[n] - xs[n - 1]) * (xs[n] - xs[n - 1]));
+
+      return this.solve(A, ks);
+    },
+
+    solve: function(A, ks) {
+      var m = A.length;
+      for (var k = 0; k < m; k++) // column
+      {
+        // pivot for column
+        var i_max = 0;
+        var vali = Number.NEGATIVE_INFINITY;
+        for (var i = k; i < m; i++)
+          if (A[i][k] > vali) {
+            i_max = i;
+            vali = A[i][k];
+          }
+        this.splineSwapRows(A, k, i_max);
+
+        // for all rows below pivot
+        for (var i = k + 1; i < m; i++) {
+          for (var j = k + 1; j < m + 1; j++)
+            A[i][j] = A[i][j] - A[k][j] * (A[i][k] / A[k][k]);
+          A[i][k] = 0;
+        }
+      }
+      for (var i = m - 1; i >= 0; i--) // rows = columns
+      {
+        var v = A[i][m] / A[i][i];
+        ks[i] = v;
+        for (var j = i - 1; j >= 0; j--) // rows
+        {
+          A[j][m] -= A[j][i] * v;
+          A[j][i] = 0;
+        }
+      }
+      return ks;
+    },
+
+    zerosMat: function(r, c) {
+      var A = [];
+      for (var i = 0; i < r; i++) {
+        A.push([]);
+        for (var j = 0; j < c; j++) A[i].push(0);
+      }
+      return A;
+    },
+
+    splineSwapRows: function(m, k, l) {
+      var p = m[k];
+      m[k] = m[l];
+      m[l] = p;
+    }
+  });
+
+window.ease = ease;
+
+})();
+
+
+/* file: src/Playground.js */
+
+PLAYGROUND = {};
+
+function playground(args) {
+
+  return new PLAYGROUND.Application(args);
+
+};
+
+/* file: src/Utils.js */
+
+PLAYGROUND.Utils = {
+
+  extend: function() {
+
+    for (var i = 1; i < arguments.length; i++) {
+      for (var j in arguments[i]) {
+        arguments[0][j] = arguments[i][j];
+      }
+    }
+
+    return arguments[0];
+
+  },
+
+  merge: function(a) {
+
+    for (var i = 1; i < arguments.length; i++) {
+
+      var b = arguments[i];
+
+      for (var key in b) {
+
+        var value = b[key];
+
+        if (typeof a[key] !== "undefined") {
+          if (typeof a[key] === "object") this.merge(a[key], value);
+          else a[key] = value;
+        } else {
+          a[key] = value;
+        }
+      }
+    }
+    return a;
+
+  },
+
+  invoke: function(object, methodName) {
+
+    var args = Array.prototype.slice.call(arguments, 2);
+
+    for (var i = 0; i < object.length; i++) {
+      var current = object[i];
+
+      if (current[methodName]) current[methodName].apply(current, args);
+
+    }
+
+  },
+
+  throttle: function(fn, threshold) {
+    threshold || (threshold = 250);
+    var last,
+      deferTimer;
+    return function() {
+      var context = this;
+
+      var now = +new Date,
+        args = arguments;
+      if (last && now < last + threshold) {
+        // hold on to it
+        clearTimeout(deferTimer);
+        deferTimer = setTimeout(function() {
+          last = now;
+          fn.apply(context, args);
+        }, threshold);
+      } else {
+        last = now;
+        fn.apply(context, args);
+      }
+    };
+  }
+
+};
+
+PLAYGROUND.Utils.ease = ease;
+
+
+/* file: src/Events.js */
+
+PLAYGROUND.Events = function() {
+
+  this.listeners = {};
+
+};
+
+PLAYGROUND.Events.prototype = {
+
+  on: function(event, callback, context) {
+
+    if (typeof event === "object") {
+      var result = {};
+      for (var key in event) {
+        result[key] = this.on(key, event[key], context)
+      }
+      return result;
+    }
+
+    if (!this.listeners[event]) this.listeners[event] = [];
+
+    var listener = {
+      once: false,
+      callback: callback,
+      context: context
+    };
+
+    this.listeners[event].push(listener);
+
+    return listener;
+  },
+
+  once: function(event, callback, context) {
+
+    if (typeof event === "object") {
+      var result = {};
+      for (var key in event) {
+        result[key] = this.once(key, event[key], context)
+      }
+      return result;
+    }
+
+    if (!this.listeners[event]) this.listeners[event] = [];
+
+    var listener = {
+      once: true,
+      callback: callback,
+      context: context
+    };
+
+    this.listeners[event].push(listener);
+
+    return listener;
+  },
+
+  off: function(event, callback) {
+
+    for (var i = 0, len = this.listeners[event].length; i < len; i++) {
+      if (this.listeners[event][i]._remove) {
+        this.listeners[event].splice(i--, 1);
+        len--;
+      }
+    }
+
+  },
+
+  trigger: function(event, data) {
+
+    /* if you prefer events pipe */
+
+    if (this.listeners["event"]) {
+
+      for (var i = 0, len = this.listeners["event"].length; i < len; i++) {
+
+        var listener = this.listeners["event"][i];
+
+        listener.callback.call(listener.context || this, event, data);
+
+      }
+
+    }
+
+    /* or subscribed to single event */
+
+    if (this.listeners[event]) {
+      for (var i = 0, len = this.listeners[event].length; i < len; i++) {
+
+        var listener = this.listeners[event][i];
+
+        listener.callback.call(listener.context || this, data);
+
+        if (listener.once) {
+          this.listeners[event].splice(i--, 1);
+          len--;
+        }
+      }
+    }
+
+  }
+
+};
+
+/* file: src/States.js */
+
+PLAYGROUND.States = function(app) {
+
+  this.app = app;
+
+  PLAYGROUND.Events.call(this);
+
+  app.on("step", this.step.bind(this));
+
+};
+
+PLAYGROUND.States.prototype = {
+
+  step: function(delta) {
+
+    if (!this.next) return;
+
+    if (this.current && this.current.locked) return;
+
+    var state = this.next;
+
+    if(typeof state === "function") state = new state;
+
+    /* create state if object has never been used as a state before */
+
+    if (!state.__created) {
+
+      state.__created = true;
+
+      state.app = this.app;
+
+      this.trigger("createstate", {
+        state: state
+      });
+
+      if (state.create) state.create();
+
+    }
+
+    /* enter new state */
+
+    if (this.current) {
+      this.trigger("leavestate", {
+        prev: this.current,
+        next: state,
+        state: this.current
+      });
+    }
+
+    this.trigger("enterstate", {
+      prev: this.current,
+      next: state,
+      state: state
+    });
+
+    this.current = state;
+
+    if (this.current && this.current.enter) {
+      this.current.enter();
+    }
+
+    this.app.state = this.current;
+
+    this.next = false;
+
+
+  },
+
+  set: function(state) {
+
+    if (this.current && this.current.leave) this.current.leave();
+
+    this.next = state;
+
+    this.step(0);
+
+  }
+
+
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.States.prototype, PLAYGROUND.Events.prototype);
+
+/* file: src/Application.js */
+
+PLAYGROUND.Application = function(args) {
+
+  var app = this;
+
+  /* events */
+
+  PLAYGROUND.Events.call(this);
+
+  /* defaults */
+
+  PLAYGROUND.Utils.merge(this, this.defaults, args);
+
+  /* guess scaling mode */
+
+  this.autoWidth = this.width ? false : true;
+  this.autoHeight = this.height ? false : true;
+  this.autoScale = this.scale ? false : true;
+
+  /* get container */
+
+  if (!this.container) this.container = document.body;
+
+  if (this.container !== document.body) this.customContainer = true;
+
+  if (typeof this.container === "string") this.container = document.querySelector(this.container);
+
+  this.updateSize();
+
+  /* events */
+
+  // this.emitLocalEvent = this.emitLocalEvent.bind(this);
+  // this.emitGlobalEvent = this.emitGlobalEvent.bind(this);
+
+  /* states manager */
+
+  this.states = new PLAYGROUND.States(this);
+  this.states.on("event", this.emitLocalEvent, this);
+
+  /* mouse */
+
+  this.mouse = new PLAYGROUND.Mouse(this, this.container);
+  this.mouse.on("event", this.emitGlobalEvent, this);
+
+  /* touch */
+
+  this.touch = new PLAYGROUND.Touch(this, this.container);
+  this.touch.on("event", this.emitGlobalEvent, this);
+
+  /* keyboard */
+
+  this.keyboard = new PLAYGROUND.Keyboard();
+  this.keyboard.on("event", this.emitGlobalEvent, this);
+
+  /* gamepads */
+
+  this.gamepads = new PLAYGROUND.Gamepads(this);
+  this.gamepads.on("event", this.emitGlobalEvent, this);
+
+  /* tweens */
+
+  this.tweens = new PLAYGROUND.TweenManager(this);
+
+  /* ease */
+
+  this.ease = PLAYGROUND.Utils.ease;
+
+  /* video recorder */
+
+  // this.videoRecorder = new PLAYGROUND.VideoRecorder(this);
+
+  /* sound */
+
+  PLAYGROUND.Sound(this);
+
+  /* window resize */
+
+  window.addEventListener("resize", this.handleResize.bind(this));
+
+  /* assets containers */
+
+  this.images = {};
+  this.atlases = {};
+  this.data = {};
+
+  this.loader = new PLAYGROUND.Loader(this);
+
+  this.loadFoo(0.25);
+
+  /* create plugins in the same way */
+
+  this.plugins = [];
+
+  for (var key in PLAYGROUND) {
+
+    var property = PLAYGROUND[key];
+
+    if (property.plugin) this.plugins.push(new property(this));
+
+  }
+
+  /* flow */
+
+  this.emitGlobalEvent("preload");
+
+  this.firstBatch = true;
+
+  if (this.disabledUntilLoaded) this.skipEvents = true;
+
+  function onPreloadEnd() {
+
+    app.loadFoo(0.25);
+
+    /* run everything in the next frame */
+
+    setTimeout(function() {
+
+      app.emitLocalEvent("create");
+
+      app.setState(PLAYGROUND.DefaultState);
+      app.handleResize();
+
+      if (PLAYGROUND.LoadingScreen) app.setState(PLAYGROUND.LoadingScreen);
+
+      /* game loop */
+
+      PLAYGROUND.GameLoop(app);
+
+      /* stage proper loading step */
+
+      app.loader.once("ready", function() {
+
+        app.firstBatch = false;
+
+        if (app.disabledUntilLoaded) app.skipEvents = false;
+
+        app.setState(PLAYGROUND.DefaultState);
+
+        app.emitLocalEvent("ready");
+        app.handleResize();
+
+      });
+
+    });
+
+
+
+  };
+
+
+  this.loader.once("ready", onPreloadEnd);
+
+};
+
+PLAYGROUND.Application.prototype = {
+
+  defaults: {
+    smoothing: 1,
+    paths: {
+      base: "",
+      images: "images/"
+    },
+    offsetX: 0,
+    offsetY: 0,
+    skipEvents: false,
+    disabledUntilLoaded: true
+  },
+
+  setState: function(state) {
+
+    this.states.set(state);
+
+  },
+
+  getPath: function(to) {
+
+    return this.paths.base + (this.paths[to] || (to + "/"));
+
+  },
+
+  getAssetEntry: function(path, folder, defaultExtension) {
+
+    /* translate folder according to user provided paths 
+       or leave as is */
+
+    var folder = this.paths[folder] || (folder + "/");
+
+    var fileinfo = path.match(/(.*)\..*/);
+    var key = fileinfo ? fileinfo[1] : path;
+
+    var temp = path.split(".");
+    var basename = path;
+
+    if (temp.length > 1) {
+      var ext = temp.pop();
+      path = temp.join(".");
+    } else {
+      var ext = defaultExtension;
+      basename += "." + defaultExtension;
+    }
+
+    return {
+      key: key,
+      url: this.paths.base + folder + basename,
+      path: this.paths.base + folder + path,
+      ext: ext
+    };
+
+  },
+
+  /* events that shouldn't flow down to the state */
+
+  emitLocalEvent: function(event, data) {
+
+    this.trigger(event, data);
+
+    if ((event !== "render" || !this.skipEvents || this.loader.ready) && this[event]) this[event](data);
+
+  },
+
+  /* events that should be passed to the state */
+
+  emitGlobalEvent: function(event, data) {
+
+    if (!this.state) return this.emitLocalEvent(event, data);
+
+    this.trigger(event, data);
+
+    if ((event !== "render" || !this.skipEvents || this.loader.ready) && this.event) this.event(event, data);
+
+    if ((event !== "render" || !this.skipEvents || this.loader.ready) && this[event]) this[event](data);
+
+    if (this.state.event) this.state.event(event, data);
+
+    if (this.state[event]) this.state[event](data);
+
+    this.trigger("post" + event, data);
+
+    // if (this.state.proxy) this.state.proxy(event, data);
+
+  },
+
+  updateSize: function() {
+
+    if (this.customContainer) {
+
+      var containerWidth = this.container.offsetWidth;
+      var containerHeight = this.container.offsetHeight;
+
+    } else {
+
+      var containerWidth = window.innerWidth;
+      var containerHeight = window.innerHeight;
+
+    }
+
+    if (!this.autoScale && !this.autoWidth && !this.autoHeight) {
+
+    } else if (!this.autoHeight && this.autoWidth) {
+
+      if (this.autoScale) this.scale = containerHeight / this.height;
+
+      this.width = Math.ceil(containerWidth / this.scale);
+
+    } else if (!this.autoWidth && this.autoHeight) {
+
+      if (this.autoScale) this.scale = containerWidth / this.width;
+
+      this.height = Math.ceil(containerHeight / this.scale);
+
+
+    } else if (this.autoWidth && this.autoHeight && this.autoScale) {
+
+      this.scale = 1;
+      this.width = containerWidth;
+      this.height = containerHeight;
+
+    } else if (this.autoWidth && this.autoHeight) {
+
+      this.width = Math.ceil(containerWidth / this.scale);
+      this.height = Math.ceil(containerHeight / this.scale);
+
+    } else {
+
+      this.scale = Math.min(containerWidth / this.width, containerHeight / this.height);
+
+    }
+
+    this.offsetX = (containerWidth - this.width * this.scale) / 2 | 0;
+    this.offsetY = (containerHeight - this.height * this.scale) / 2 | 0;
+
+    this.center = {
+      x: this.width / 2 | 0,
+      y: this.height / 2 | 0
+    };
+
+  },
+
+  handleResize: function() {
+
+    this.updateSize();
+
+    this.mouse.handleResize();
+    this.touch.handleResize();
+
+    this.emitGlobalEvent("resize", {});
+
+  },
+
+  /* 
+    request a file over http 
+    it shall be later an abstraction using 'fs' in node-webkit
+
+    returns a promise
+  */
+
+  request: function(url) {
+
+    function promise(success, fail) {
+
+      var request = new XMLHttpRequest();
+
+      var app = this;
+
+      request.open("GET", url, true);
+
+      request.onload = function(event) {
+
+        var xhr = event.target;
+
+        if (xhr.status !== 200 && xhr.status !== 0) {
+
+          return fail(new Error("Failed to get " + url));
+
+        }
+
+        success(xhr);
+
+      }
+
+      request.send();
+
+    }
+
+    return new Promise(promise);
+
+  },
+
+  /* imaginary timeout to delay loading */
+
+  loadFoo: function(timeout) {
+
+    var loader = this.loader;
+
+    this.loader.add("foo " + timeout);
+
+    setTimeout(function() {
+
+      loader.success("foo " + timeout);
+
+    }, timeout * 1000);
+
+
+  },
+
+  /* data/json */
+
+  loadData: function() {
+
+    for (var i = 0; i < arguments.length; i++) {
+
+      var arg = arguments[i];
+
+      if (typeof arg === "object") {
+
+        for (var key in arg) this.loadData(arg[key]);
+
+      } else {
+
+        this.loadDataItem(arg);
+
+      }
+
+    }
+
+  },
+
+  loadDataItem: function(name) {
+
+    var entry = this.getAssetEntry(name, "data", "json");
+
+    var app = this;
+
+    this.loader.add();
+
+    this.request(entry.url).then(processData);
+
+    function processData(request) {
+
+      if (entry.ext === "json") {
+        app.data[entry.key] = JSON.parse(request.responseText);
+      } else {
+        app.data[entry.key] = request.responseText;
+      }
+
+      app.loader.success(entry.url);
+
+    }
+
+  },
+
+  /* images */
+
+  loadImage: function() {
+
+    return this.loadImages.apply(this, arguments);
+
+  },
+
+  loadImages: function() {
+
+    var promises = [];
+
+    for (var i = 0; i < arguments.length; i++) {
+
+      var arg = arguments[i];
+
+      /* polymorphism at its finest */
+
+      if (typeof arg === "object") {
+
+        for (var key in arg) promises = promises.concat(this.loadImages(arg[key]));
+
+      } else {
+
+        promises.push(this.loadOneImage(arg));
+
+      }
+
+    }
+
+    return Promise.all(promises);
+
+  },
+
+  loadOneImage: function(name) {
+
+    var app = this;
+
+    if (!this._imageLoaders) this._imageLoaders = {};
+
+    if (!this._imageLoaders[name]) {
+
+      var promise = function(resolve, reject) {
+
+        /* if argument is not an object/array let's try to load it */
+
+        var loader = app.loader;
+
+        var entry = app.getAssetEntry(name, "images", "png");
+
+        app.loader.add(entry.path);
+
+        var image = new Image;
+
+        image.addEventListener("load", function() {
+
+          app.images[entry.key] = image;
+
+          resolve(image);
+          loader.success(entry.url);
+
+          entry.image = image;
+
+          app.emitLocalEvent("imageready", entry);
+
+        });
+
+        image.addEventListener("error", function() {
+
+          reject("can't load " + entry.url);
+          loader.error(entry.url);
+
+        });
+
+        image.src = entry.url;
+
+      };
+
+      app._imageLoaders[name] = new Promise(promise);
+
+    }
+
+    return this._imageLoaders[name];
+
+  },
+
+  /* at this point it doesn't really load font
+     it just ensures the font has been loaded (use css font-face)
+  */
+
+  loadFont: function() {
+
+    var promises = [];
+
+    for (var i = 0; i < arguments.length; i++) {
+
+      var arg = arguments[i];
+
+      promises.push(this.loadFontItem(arg));
+
+    }
+
+    return Promise.all(promises);
+
+  },
+
+  loadFonts: function() {
+
+    return this.loadFont.apply(this, arguments);
+
+  },
+
+  loadFontItem: function(name) {
+
+    var app = this;
+
+    if (!this._fontPromises) this._fontPromises = {};
+
+    if (!this._fontPromises[name]) {
+
+      var promise = function(resolve, reject) {
+
+        app.loader.add("font " + name);
+
+        var checkingTimer = setInterval(function() {
+
+          var base = cq(100, 32).font("14px somethingrandom").fillStyle("#fff").textBaseline("top").fillText("lorem ipsum dolores sit", 0, 4);
+          var test = cq(100, 32).font("14px '" + name + "'").fillStyle("#fff").textBaseline("top").fillText("lorem ipsum dolores sit", 0, 4);
+
+          if (!cq.compare(base, test)) {
+
+            app.loader.success("font" + name);
+
+            clearInterval(checkingTimer);
+
+            resolve();
+
+          }
+
+        });
+
+      }
+
+      this._fontPromises[name] = new Promise(promise);
+
+    }
+
+    return this._fontPromises[name];
+
+  },
+
+
+  render: function() {
+
+  }
+
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Application.prototype, PLAYGROUND.Events.prototype);
+
+/* file: src/GameLoop.js */
+
+PLAYGROUND.GameLoop = function(app) {
+
+  app.lifetime = 0;
+  app.ops = 0;
+  app.opcost = 0;
+
+  var lastTick = Date.now();
+  var frame = 0;
+
+  function render(dt) {
+
+    app.emitGlobalEvent("prerender", dt)
+    app.emitGlobalEvent("render", dt)
+    app.emitGlobalEvent("postrender", dt)
+
+  };
+
+  function step(dt) {
+
+    app.emitGlobalEvent("step", dt)
+
+  };
+
+  function gameLoop() {
+
+    requestAnimationFrame(gameLoop);
+
+    if (app.frameskip) {
+      frame++;
+      if (frame === app.frameskip) {
+        frame = 0;
+      } else return;
+    }
+
+    var delta = Date.now() - lastTick;
+
+    lastTick = Date.now();
+
+    if (delta > 1000) return;
+
+    var dt = delta / 1000;
+
+    app.lifetime += dt;
+    app.elapsed = dt;
+
+    step(dt);
+    render(dt);
+
+    app.opcost = (Date.now() - lastTick) / 1000;
+    app.ops = 1000 / app.opcost;
+
+  };
+
+  requestAnimationFrame(gameLoop);
+
+};
+
+/* file: src/Gamepads.js */
+
+PLAYGROUND.Gamepads = function(app) {
+
+  this.app = app;
+
+  PLAYGROUND.Events.call(this);
+
+  this.getGamepads = navigator.getGamepads || navigator.webkitGetGamepads;
+
+  this.gamepadmoveEvent = {};
+  this.gamepaddownEvent = {};
+  this.gamepadupEvent = {};
+
+  this.gamepads = {};
+
+  this.app.on("step", this.step.bind(this));
+
+};
+
+PLAYGROUND.Gamepads.prototype = {
+
+  buttons: {
+    0: "1",
+    1: "2",
+    2: "3",
+    3: "4",
+    4: "l1",
+    5: "r1",
+    6: "l2",
+    7: "r2",
+    8: "select",
+    9: "start",
+    12: "up",
+    13: "down",
+    14: "left",
+    15: "right"
+  },
+
+  zeroState: function() {
+
+    var buttons = [];
+
+    for (var i = 0; i <= 15; i++) {
+      buttons.push({
+        pressed: false,
+        value: 0
+      });
+    }
+
+    return {
+      axes: [],
+      buttons: buttons
+    };
+
+  },
+
+  createGamepad: function() {
+
+    var result = {
+      buttons: {},
+      sticks: [{
+        x: 0,
+        y: 0
+      }, {
+        x: 0,
+        y: 0
+      }]
+    };
+
+
+    for (var i = 0; i < 16; i++) {
+      var key = this.buttons[i];
+      result.buttons[key] = false;
+    }
+
+    return result;
+
+  },
+
+  step: function() {
+
+    if (!navigator.getGamepads) return;
+
+    var gamepads = navigator.getGamepads();
+
+    for (var i = 0; i < gamepads.length; i++) {
+
+      var current = gamepads[i];
+
+      if (!current) continue;
+
+      if (!this[i]) this[i] = this.createGamepad();
+
+      /* have to concat the current.buttons because the are read-only */
+
+      var buttons = [].concat(current.buttons);
+
+      /* hack for missing  dpads */
+
+      for (var h = 12; h <= 15; h++) {
+        if (!buttons[h]) buttons[h] = {
+          pressed: false,
+          value: 0
+        };
+      }
+
+      var previous = this[i];
+
+      /* axes (sticks) to buttons */
+
+      if (current.axes) {
+
+        if (current.axes[0] < 0) buttons[14].pressed = true;
+        if (current.axes[0] > 0) buttons[15].pressed = true;
+        if (current.axes[1] < 0) buttons[12].pressed = true;
+        if (current.axes[1] > 0) buttons[13].pressed = true;
+
+        previous.sticks[0].x = current.axes[0];
+        previous.sticks[0].y = current.axes[1];
+        previous.sticks[1].x = current.axes[2];
+        previous.sticks[1].y = current.axes[3];
+
+      }
+
+      /* check buttons changes */
+
+      for (var j = 0; j < buttons.length; j++) {
+
+        var key = this.buttons[j];
+
+        /* gamepad down */
+
+        if (buttons[j].pressed && !previous.buttons[key]) {
+
+          previous.buttons[key] = true;
+          this.gamepaddownEvent.button = this.buttons[j];
+          this.gamepaddownEvent.gamepad = i;
+          this.trigger("gamepaddown", this.gamepaddownEvent);
+
+        }
+
+        /* gamepad up */
+        
+        else if (!buttons[j].pressed && previous.buttons[key]) {
+
+          previous.buttons[key] = false;
+          this.gamepadupEvent.button = this.buttons[j];
+          this.gamepadupEvent.gamepad = i;
+          this.trigger("gamepadup", this.gamepadupEvent);
+
+        }
+
+      }
+
+    }
+
+  }
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Gamepads.prototype, PLAYGROUND.Events.prototype);
+
+
+/* file: src/Keyboard.js */
+
+PLAYGROUND.Keyboard = function() {
+
+  PLAYGROUND.Events.call(this);
+
+  this.keys = {};
+
+  document.addEventListener("keydown", this.keydown.bind(this));
+  document.addEventListener("keyup", this.keyup.bind(this));
+  document.addEventListener("keypress", this.keypress.bind(this));
+
+  this.keydownEvent = {};
+  this.keyupEvent = {};
+
+  this.preventDefault = true;
+
+};
+
+PLAYGROUND.Keyboard.prototype = {
+
+  keycodes: {
+    37: "left",
+    38: "up",
+    39: "right",
+    40: "down",
+    45: "insert",
+    46: "delete",
+    8: "backspace",
+    9: "tab",
+    13: "enter",
+    16: "shift",
+    17: "ctrl",
+    18: "alt",
+    19: "pause",
+    20: "capslock",
+    27: "escape",
+    32: "space",
+    33: "pageup",
+    34: "pagedown",
+    35: "end",
+    36: "home",
+    112: "f1",
+    113: "f2",
+    114: "f3",
+    115: "f4",
+    116: "f5",
+    117: "f6",
+    118: "f7",
+    119: "f8",
+    120: "f9",
+    121: "f10",
+    122: "f11",
+    123: "f12",
+    144: "numlock",
+    145: "scrolllock",
+    186: "semicolon",
+    187: "equal",
+    188: "comma",
+    189: "dash",
+    190: "period",
+    191: "slash",
+    192: "graveaccent",
+    219: "openbracket",
+    220: "backslash",
+    221: "closebraket",
+    222: "singlequote"
+  },
+
+  keypress: function(e) {
+
+  },
+
+  bypassKeys: ["f12", "f5", "ctrl", "alt", "shift"],
+
+  keydown: function(e) {
+
+    if (e.which >= 48 && e.which <= 90) var keyName = String.fromCharCode(e.which).toLowerCase();
+    else var keyName = this.keycodes[e.which];
+
+    if (this.keys[keyName]) return;
+
+    this.keydownEvent.key = keyName;
+    this.keydownEvent.original = e;
+
+    this.keys[keyName] = true;
+
+    this.trigger("keydown", this.keydownEvent);
+
+    if (this.preventDefault && document.activeElement === document.body) {
+
+      var bypass = e.metaKey;
+
+      if (!bypass) {
+        for (var i = 0; i < this.bypassKeys.length; i++) {
+
+          if (this.keys[this.bypassKeys[i]]) {
+            bypass = true;
+            break
+          }
+
+        }
+      }
+
+      if (!bypass) {
+        e.returnValue = false;
+        e.keyCode = 0;
+        e.preventDefault();
+        e.stopPropagation();
+      }
+
+    }
+
+  },
+
+  keyup: function(e) {
+
+    if (e.which >= 48 && e.which <= 90) var keyName = String.fromCharCode(e.which).toLowerCase();
+    else var keyName = this.keycodes[e.which];
+
+    this.keyupEvent.key = keyName;
+    this.keyupEvent.original = e;
+
+    this.keys[keyName] = false;
+
+    this.trigger("keyup", this.keyupEvent);
+
+  }
+
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Keyboard.prototype, PLAYGROUND.Events.prototype);
+
+/* file: src/Pointer.js */
+
+PLAYGROUND.Pointer = function(app) {
+
+  this.app = app;
+
+  app.on("touchstart", this.touchstart, this);
+  app.on("touchend", this.touchend, this);
+  app.on("touchmove", this.touchmove, this);
+
+  app.on("mousemove", this.mousemove, this);
+  app.on("mousedown", this.mousedown, this);
+  app.on("mouseup", this.mouseup, this);
+  app.on("mousewheel", this.mousewheel, this);
+
+  this.pointers = app.pointers = {};
+
+};
+
+PLAYGROUND.Pointer.plugin = true;
+
+PLAYGROUND.Pointer.prototype = {
+
+  updatePointer: function(pointer) {
+
+    this.pointers[pointer.id] = pointer;
+
+  },
+
+  removePointer: function(pointer) {
+
+    delete this.pointers[pointer.id];
+
+  },
+
+  touchstart: function(e) {
+
+    e.touch = true;
+
+    this.updatePointer(e);
+
+    this.app.emitGlobalEvent("pointerdown", e);
+
+  },
+
+  touchend: function(e) {
+
+    e.touch = true;
+
+    this.removePointer(e);
+
+    this.app.emitGlobalEvent("pointerup", e);
+
+  },
+
+  touchmove: function(e) {
+
+    e.touch = true;
+
+    this.updatePointer(e);
+
+    this.app.emitGlobalEvent("pointermove", e);
+
+  },
+
+  mousemove: function(e) {
+
+    e.mouse = true;
+
+    this.updatePointer(e);
+
+    this.app.emitGlobalEvent("pointermove", e);
+
+  },
+
+  mousedown: function(e) {
+
+    e.mouse = true;
+
+    this.app.emitGlobalEvent("pointerdown", e);
+
+  },
+
+  mouseup: function(e) {
+
+    e.mouse = true;
+
+    this.app.emitGlobalEvent("pointerup", e);
+
+  },
+
+  mousewheel: function(e) {
+
+    e.mouse = true;
+
+    this.app.emitGlobalEvent("pointerwheel", e);
+
+  }
+
+};
+
+/* file: src/Loader.js */
+
+/* Loader */
+
+PLAYGROUND.Loader = function(app) {
+
+  this.app = app;
+
+  PLAYGROUND.Events.call(this);
+
+  this.reset();
+
+};
+
+PLAYGROUND.Loader.prototype = {
+
+  /* loader */
+
+  add: function(id) {
+
+    this.queue++;
+    this.count++;
+    this.ready = false;
+    this.trigger("add", id);
+
+    return id;
+
+  },
+
+  error: function(id) {
+
+    this.trigger("error", id);
+
+  },
+
+  success: function(id) {
+
+    this.queue--;   
+
+    this.progress = 1 - this.queue / this.count;
+
+    this.trigger("load", id);
+
+    if (this.queue <= 0) {
+      this.reset();
+      this.trigger("ready");
+    }
+    
+  },
+
+  reset: function() {
+
+    this.progress = 0;
+    this.queue = 0;
+    this.count = 0;
+    this.ready = true;
+
+  }
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Loader.prototype, PLAYGROUND.Events.prototype);
+
+/* file: src/Mouse.js */
+
+PLAYGROUND.Mouse = function(app, element) {
+
+  var self = this;
+
+  this.app = app;
+
+  PLAYGROUND.Events.call(this);
+
+  this.element = element;
+
+  this.buttons = {};
+
+  this.preventContextMenu = true;
+
+  this.mousemoveEvent = {};
+  this.mousedownEvent = {};
+  this.mouseupEvent = {};
+  this.mousewheelEvent = {};
+
+  this.x = 0;
+  this.y = 0;
+
+  element.addEventListener("mousemove", this.mousemove.bind(this));
+  element.addEventListener("mousedown", this.mousedown.bind(this));
+  element.addEventListener("mouseup", this.mouseup.bind(this));
+
+  this.enableMousewheel();
+
+  this.element.addEventListener("contextmenu", function(e) {
+    if (self.preventContextMenu && !e.metaKey) e.preventDefault();
+  });
+
+  element.requestPointerLock = element.requestPointerLock ||
+    element.mozRequestPointerLock ||
+    element.webkitRequestPointerLock;
+
+  document.exitPointerLock = document.exitPointerLock ||
+    document.mozExitPointerLock ||
+    document.webkitExitPointerLock;
+
+
+  this.handleResize();
+};
+
+PLAYGROUND.Mouse.prototype = {
+
+  lock: function() {
+
+    this.locked = true;
+    this.element.requestPointerLock();
+
+  },
+
+  unlock: function() {
+
+    this.locked = false;
+    document.exitPointerLock();
+
+  },
+
+  getElementOffset: function(element) {
+
+    var offsetX = 0;
+    var offsetY = 0;
+
+    do {
+      offsetX += element.offsetLeft;
+      offsetY += element.offsetTop;
+    }
+
+    while ((element = element.offsetParent));
+
+    return {
+      x: offsetX,
+      y: offsetY
+    };
+
+  },
+
+  handleResize: function() {
+
+    this.elementOffset = this.getElementOffset(this.element);
+
+  },
+
+  mousemove: PLAYGROUND.Utils.throttle(function(e) {
+
+    this.x = this.mousemoveEvent.x = (e.pageX - this.elementOffset.x - this.app.offsetX) / this.app.scale | 0;
+    this.y = this.mousemoveEvent.y = (e.pageY - this.elementOffset.y - this.app.offsetY) / this.app.scale | 0;
+
+    this.mousemoveEvent.original = e;
+
+    if (this.locked) {
+      this.mousemoveEvent.movementX = e.movementX ||
+        e.mozMovementX ||
+        e.webkitMovementX ||
+        0;
+
+      this.mousemoveEvent.movementY = e.movementY ||
+        e.mozMovementY ||
+        e.webkitMovementY ||
+        0;
+    }
+
+    if (this.app.mouseToTouch) {
+      //      if (this.left) {
+      this.mousemoveEvent.id = this.mousemoveEvent.identifier = 255;
+      this.trigger("touchmove", this.mousemoveEvent);
+      //      }
+    } else {
+      this.mousemoveEvent.id = this.mousemoveEvent.identifier = 255;
+      this.trigger("mousemove", this.mousemoveEvent);
+    }
+
+  }, 16),
+
+  mousedown: function(e) {
+
+    var buttonName = ["left", "middle", "right"][e.button];
+
+    this.mousedownEvent.x = this.mousemoveEvent.x;
+    this.mousedownEvent.y = this.mousemoveEvent.y;
+    this.mousedownEvent.button = buttonName;
+    this.mousedownEvent.original = e;
+
+    this[buttonName] = true;
+
+    this.mousedownEvent.id = this.mousedownEvent.identifier = 255;
+
+    if (this.app.mouseToTouch) {
+      this.trigger("touchmove", this.mousedownEvent);
+      this.trigger("touchstart", this.mousedownEvent);
+    } else {
+      this.trigger("mousedown", this.mousedownEvent);
+    }
+
+  },
+
+  mouseup: function(e) {
+
+    var buttonName = ["left", "middle", "right"][e.button];
+
+    this.mouseupEvent.x = this.mousemoveEvent.x;
+    this.mouseupEvent.y = this.mousemoveEvent.y;
+    this.mouseupEvent.button = buttonName;
+    this.mouseupEvent.original = e;
+
+    this.mouseupEvent.id = this.mouseupEvent.identifier = 255;
+
+    if (this.app.mouseToTouch) {
+
+      this.trigger("touchend", this.mouseupEvent);
+
+    } else {
+
+      this.trigger("mouseup", this.mouseupEvent);
+
+    }
+
+    this[buttonName] = false;
+    
+  },
+
+  mousewheel: function(e) {
+
+    this.mousewheelEvent.x = this.mousemoveEvent.x;
+    this.mousewheelEvent.y = this.mousemoveEvent.y;
+    this.mousewheelEvent.button = ["none", "left", "middle", "right"][e.button];
+    this.mousewheelEvent.original = e;
+    this.mousewheelEvent.id = this.mousewheelEvent.identifier = 255;
+
+    this[e.button] = false;
+
+    this.trigger("mousewheel", this.mousewheelEvent);
+
+  },
+
+
+  enableMousewheel: function() {
+
+    var eventNames = 'onwheel' in document || document.documentMode >= 9 ? ['wheel'] : ['mousewheel', 'DomMouseScroll', 'MozMousePixelScroll'];
+    var callback = this.mousewheel.bind(this);
+    var self = this;
+
+    for (var i = eventNames.length; i;) {
+
+      self.element.addEventListener(eventNames[--i], PLAYGROUND.Utils.throttle(function(event) {
+
+        var orgEvent = event || window.event,
+          args = [].slice.call(arguments, 1),
+          delta = 0,
+          deltaX = 0,
+          deltaY = 0,
+          absDelta = 0,
+          absDeltaXY = 0,
+          fn;
+
+        orgEvent.type = "mousewheel";
+
+        // Old school scrollwheel delta
+        if (orgEvent.wheelDelta) {
+          delta = orgEvent.wheelDelta;
+        }
+
+        if (orgEvent.detail) {
+          delta = orgEvent.detail * -1;
+        }
+
+        // New school wheel delta (wheel event)
+        if (orgEvent.deltaY) {
+          deltaY = orgEvent.deltaY * -1;
+          delta = deltaY;
+        }
+
+        // Webkit
+        if (orgEvent.wheelDeltaY !== undefined) {
+          deltaY = orgEvent.wheelDeltaY;
+        }
+
+        var result = delta ? delta : deltaY;
+
+        self.mousewheelEvent.x = self.mousemoveEvent.x;
+        self.mousewheelEvent.y = self.mousemoveEvent.y;
+        self.mousewheelEvent.delta = result / Math.abs(result);
+        self.mousewheelEvent.original = orgEvent;
+
+        callback(self.mousewheelEvent);
+
+        orgEvent.preventDefault();
+
+      }, 40), false);
+    }
+
+  }
+
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Mouse.prototype, PLAYGROUND.Events.prototype);
+
+/* file: src/Sound.js */
+
+PLAYGROUND.Sound = function(app) {
+
+  var audioContext = window.AudioContext || window.webkitAudioContext || window.mozAudioContext;
+
+  if (audioContext) {
+
+    if (!PLAYGROUND.audioContext) PLAYGROUND.audioContext = new audioContext;
+
+    app.audioContext = PLAYGROUND.audioContext;
+    app.sound = new PLAYGROUND.SoundWebAudioAPI(app, app.audioContext);
+    app.music = new PLAYGROUND.SoundWebAudioAPI(app, app.audioContext);
+
+  } else {
+
+    app.sound = new PLAYGROUND.SoundAudio(app);
+    app.music = new PLAYGROUND.SoundAudio(app);
+
+  }
+
+};
+
+PLAYGROUND.Application.prototype.playSound = function(key, loop) {
+
+  return this.sound.play(key, loop);
+
+};
+
+PLAYGROUND.Application.prototype.stopSound = function(sound) {
+
+  this.sound.stop(sound);
+
+};
+
+PLAYGROUND.Application.prototype.loadSound = function() {
+
+  return this.loadSounds.apply(this, arguments);
+
+};
+
+PLAYGROUND.Application.prototype.loadSounds = function() {
+
+  for (var i = 0; i < arguments.length; i++) {
+
+    var arg = arguments[i];
+
+    /* polymorphism at its finest */
+
+    if (typeof arg === "object") {
+
+      for (var key in arg) this.loadSounds(arg[key]);
+
+    } else {
+      this.sound.load(arg);
+    }
+  }
+
+};
+
+/* file: src/SoundWebAudioAPI.js */
+
+PLAYGROUND.SoundWebAudioAPI = function(app, audioContext) {
+
+  this.app = app;
+
+  var canPlayMp3 = (new Audio).canPlayType("audio/mp3");
+  var canPlayOgg = (new Audio).canPlayType('audio/ogg; codecs="vorbis"');
+
+  if (this.app.preferedAudioFormat === "mp3") {
+
+    if (canPlayMp3) this.audioFormat = "mp3";
+    else this.audioFormat = "ogg";
+
+  } else {
+
+    if (canPlayOgg) this.audioFormat = "ogg";
+    else this.audioFormat = "mp3";
+
+  }
+
+  this.context = audioContext;
+
+  this.gainNode = this.context.createGain()
+  this.gainNode.connect(this.context.destination);
+
+  this.compressor = this.context.createDynamicsCompressor();
+  this.compressor.connect(this.gainNode);
+
+  this.output = this.gainNode;
+
+  this.gainNode.gain.value = 1.0;
+
+  this.pool = [];
+  this.volume = 1.0;
+
+  this.setMasterPosition(0, 0, 0);
+
+  this.loops = [];
+
+  this.app.on("step", this.step.bind(this));
+
+};
+
+PLAYGROUND.SoundWebAudioAPI.prototype = {
+
+  buffers: {},
+  aliases: {},
+
+  alias: function(alias, source, volume, rate) {
+
+    this.aliases[alias] = {
+      source: source,
+      volume: volume,
+      rate: rate
+    };
+
+  },
+
+  setMaster: function(volume) {
+
+    this.volume = volume;
+
+    this.gainNode.gain.value = volume;
+
+  },
+
+  load: function(file) {
+
+    var entry = this.app.getAssetEntry(file, "sounds", this.audioFormat);
+
+    var sampler = this;
+
+    var request = new XMLHttpRequest();
+
+    request.open("GET", entry.url, true);
+    request.responseType = "arraybuffer";
+
+    var id = this.app.loader.add(entry.url);
+
+    request.onload = function() {
+
+      sampler.context.decodeAudioData(this.response, function(decodedBuffer) {
+        sampler.buffers[entry.key] = decodedBuffer;
+        sampler.app.loader.success(entry.url);
+      });
+
+    }
+
+    request.send();
+
+  },
+
+  cleanArray: function(array, property) {
+    for (var i = 0, len = array.length; i < len; i++) {
+      if (array[i] === null || (property && array[i][property])) {
+        array.splice(i--, 1);
+        len--;
+      }
+    }
+  },
+
+  setMasterPosition: function(x, y, z) {
+
+    this.masterPosition = {
+      x: x,
+      y: y,
+      z: z
+    };
+
+    this.context.listener.setPosition(x, y, z)
+      // this.context.listener.setOrientation(0, 0, -1, 0, 1, 0);
+      // this.context.listener.dopplerFactor = 1;
+      // this.context.listener.speedOfSound = 343.3;
+  },
+
+  getSoundBuffer: function() {
+    if (!this.pool.length) {
+      for (var i = 0; i < 100; i++) {
+
+        var buffer, gain, panner;
+
+        var nodes = [
+          buffer = this.context.createBufferSource(),
+          gain = this.context.createGain(),
+          panner = this.context.createPanner()
+        ];
+
+        panner.distanceModel = "linear";
+
+        // 1 - rolloffFactor * (distance - refDistance) / (maxDistance - refDistance)
+        // refDistance / (refDistance + rolloffFactor * (distance - refDistance))
+        panner.refDistance = 1;
+        panner.maxDistance = 600;
+        panner.rolloffFactor = 1.0;
+
+
+        // panner.setOrientation(-1, -1, 0);
+
+        this.pool.push(nodes);
+
+        nodes[0].connect(nodes[1]);
+        // nodes[1].connect(nodes[2]);
+        nodes[1].connect(this.output);
+      }
+    }
+
+    return this.pool.pop();
+  },
+
+  play: function(name, loop) {
+
+    var alias = this.aliases[name];
+
+    var nodes = this.getSoundBuffer();
+
+    if (alias) name = alias.source;
+
+    bufferSource = nodes[0];
+    bufferSource.gainNode = nodes[1];
+    bufferSource.pannerNode = nodes[2];
+    bufferSource.buffer = this.buffers[name];
+    bufferSource.loop = loop || false;
+    bufferSource.key = name;
+
+    bufferSource.alias = alias;
+
+    this.setVolume(bufferSource, 1.0);
+    this.setPlaybackRate(bufferSource, 1.0);
+
+    if (this.loop) {
+      //  bufferSource.loopStart = this.loopStart;
+      // bufferSource.loopEnd = this.loopEnd;
+    }
+
+
+    bufferSource.start(0);
+
+    bufferSource.volumeLimit = 1;
+
+    this.setPosition(bufferSource, this.masterPosition.x, this.masterPosition.y, this.masterPosition.z);
+
+    return bufferSource;
+  },
+
+  stop: function(what) {
+
+    if (!what) return;
+
+    what.stop(0);
+
+  },
+
+  setPlaybackRate: function(sound, rate) {
+
+    if (!sound) return;
+
+    if (sound.alias) rate *= sound.alias.rate;
+
+    return sound.playbackRate.value = rate;
+  },
+
+  setPosition: function(sound, x, y, z) {
+
+    if (!sound) return;
+
+    sound.pannerNode.setPosition(x, y || 0, z || 0);
+  },
+
+  setVelocity: function(sound, x, y, z) {
+
+    if (!sound) return;
+
+    sound.pannerNode.setPosition(x, y || 0, z || 0);
+
+  },
+
+  getVolume: function(sound) {
+
+    if (!sound) return;
+
+    return sound.gainNode.gain.value;
+
+  },
+
+  setVolume: function(sound, volume) {
+
+    if (!sound) return;
+
+    if (sound.alias) volume *= sound.alias.volume;
+
+    return sound.gainNode.gain.value = Math.max(0, volume);
+  },
+
+  fadeOut: function(sound) {
+
+    if (!sound) return;
+
+    sound.fadeOut = true;
+
+    this.loops.push(sound);
+
+    return sound;
+
+  },
+
+  fadeIn: function(sound) {
+
+    if (!sound) return;
+
+    sound.fadeIn = true;
+
+    this.loops.push(sound);
+    this.setVolume(sound, 0);
+
+
+    return sound;
+
+  },
+
+  step: function(delta) {
+
+    for (var i = 0; i < this.loops.length; i++) {
+
+      var loop = this.loops[i];
+
+      if (loop.fadeIn) {
+        var volume = this.getVolume(loop);
+        volume = this.setVolume(loop, Math.min(1.0, volume + delta * 0.5));
+
+        if (volume >= 1.0) {
+          this.loops.splice(i--, 1);
+        }
+      }
+
+      if (loop.fadeOut) {
+        var volume = this.getVolume(loop);
+        volume = this.setVolume(loop, Math.min(1.0, volume - delta * 0.5));
+
+        if (volume <= 0) {
+          this.loops.splice(i--, 1);
+          this.stop(loop);
+        }
+      }
+
+    }
+
+  }
+
+};
+
+/* file: src/SoundAudio.js */
+
+PLAYGROUND.SoundAudio = function(app) {
+
+  this.app = app;  
+
+  var canPlayMp3 = (new Audio).canPlayType("audio/mp3");
+  var canPlayOgg = (new Audio).canPlayType('audio/ogg; codecs="vorbis"');
+
+  if (this.app.preferedAudioFormat === "mp3") {
+
+    if (canPlayMp3) this.audioFormat = "mp3";
+    else this.audioFormat = "ogg";
+
+  } else {
+
+    if (canPlayOgg) this.audioFormat = "ogg";
+    else this.audioFormat = "mp3";
+
+  }
+
+};
+
+PLAYGROUND.SoundAudio.prototype = {
+
+  samples: {},
+
+  setMaster: function(volume) {
+
+    this.volume = volume;
+
+  },
+
+  setMasterPosition: function() {
+
+  },
+
+  setPosition: function(x, y, z) {
+    return;
+  },
+
+  load: function(file) {
+
+    var url = "sounds/" + file + "." + this.audioFormat;
+
+    var loader = this.app.loader;
+
+    this.app.loader.add(url);
+
+    var audio = this.samples[file] = new Audio;
+
+    audio.addEventListener("canplay", function() {
+      loader.success(url);
+    });
+
+    audio.addEventListener("error", function() {
+      loader.error(url);
+    });
+
+    audio.src = url;
+
+  },
+
+  play: function(key, loop) {
+
+    var sound = this.samples[key];
+
+    sound.currentTime = 0;
+    sound.loop = loop;
+    sound.play();
+
+    return sound;
+
+  },
+
+  stop: function(what) {
+
+    if (!what) return;
+
+    what.pause();
+
+  },
+
+  step: function(delta) {
+
+  },
+
+  setPlaybackRate: function(sound, rate) {
+
+    return;
+  },
+
+  setVolume: function(sound, volume) {
+
+    sound.volume = volume * this.volume;
+
+  },
+
+  setPosition: function() {
+
+  }
+
+};
+
+/* file: src/Touch.js */
+
+PLAYGROUND.Touch = function(app, element) {
+
+  PLAYGROUND.Events.call(this);
+
+  this.app = app;
+
+  this.element = element;
+
+  this.buttons = {};
+
+  this.touches = {};
+
+  this.x = 0;
+  this.y = 0;
+
+  element.addEventListener("touchmove", this.touchmove.bind(this));
+  element.addEventListener("touchstart", this.touchstart.bind(this));
+  element.addEventListener("touchend", this.touchend.bind(this));
+
+};
+
+PLAYGROUND.Touch.prototype = {
+
+  getElementOffset: function(element) {
+
+    var offsetX = 0;
+    var offsetY = 0;
+
+    do {
+      offsetX += element.offsetLeft;
+      offsetY += element.offsetTop;
+    }
+
+    while ((element = element.offsetParent));
+
+    return {
+      x: offsetX,
+      y: offsetY
+    };
+
+  },
+
+  handleResize: function() {
+
+    this.elementOffset = this.getElementOffset(this.element);
+
+  },
+
+  touchmove: function(e) {
+
+    for (var i = 0; i < e.changedTouches.length; i++) {
+
+      var touch = e.changedTouches[i];
+
+      touchmoveEvent = {}
+
+      this.x = touchmoveEvent.x = (touch.pageX - this.elementOffset.x - this.app.offsetX) / this.app.scale | 0;
+      this.y = touchmoveEvent.y = (touch.pageY - this.elementOffset.y - this.app.offsetY) / this.app.scale | 0;
+
+      touchmoveEvent.original = touch;
+      touchmoveEvent.id = touchmoveEvent.identifier = touch.identifier;
+
+      this.touches[touch.identifier].x = touchmoveEvent.x;
+      this.touches[touch.identifier].y = touchmoveEvent.y;
+
+      this.trigger("touchmove", touchmoveEvent);
+
+    }
+
+    e.preventDefault();
+
+  },
+
+  touchstart: function(e) {
+
+    for (var i = 0; i < e.changedTouches.length; i++) {
+
+      var touch = e.changedTouches[i];
+
+      var touchstartEvent = {}
+
+      this.x = touchstartEvent.x = (touch.pageX - this.elementOffset.x - this.app.offsetX) / this.app.scale | 0;
+      this.y = touchstartEvent.y = (touch.pageY - this.elementOffset.y - this.app.offsetY) / this.app.scale | 0;
+
+      touchstartEvent.original = e.touch;
+      touchstartEvent.id = touchstartEvent.identifier = touch.identifier;
+
+      this.touches[touch.identifier] = {
+        x: touchstartEvent.x,
+        y: touchstartEvent.y
+      };
+
+      this.trigger("touchstart", touchstartEvent);
+
+    }
+
+    e.preventDefault();
+
+  },
+
+  touchend: function(e) {
+
+    for (var i = 0; i < e.changedTouches.length; i++) {
+
+      var touch = e.changedTouches[i];
+      var touchendEvent = {};
+
+      touchendEvent.x = (touch.pageX - this.elementOffset.x - this.app.offsetX) / this.app.scale | 0;
+      touchendEvent.y = (touch.pageY - this.elementOffset.y - this.app.offsetY) / this.app.scale | 0;
+
+      touchendEvent.original = touch;
+      touchendEvent.id = touchendEvent.identifier = touch.identifier;
+
+      delete this.touches[touch.identifier];
+
+      this.trigger("touchend", touchendEvent);
+
+    }
+
+    e.preventDefault();
+
+  }
+
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Touch.prototype, PLAYGROUND.Events.prototype);
+
+/* file: src/Tween.js */
+
+PLAYGROUND.Tween = function(manager, context) {
+
+  PLAYGROUND.Events.call(this);
+
+  this.manager = manager;
+  this.context = context;
+
+  PLAYGROUND.Utils.extend(this, {
+
+    actions: [],
+    index: -1,
+
+    prevEasing: "045",
+    prevDuration: 0.5
+
+  });
+
+  this.current = false;
+
+};
+
+PLAYGROUND.Tween.prototype = {
+
+  add: function(properties, duration, easing) {
+
+    if (duration) this.prevDuration = duration;
+    else duration = 0.5;
+    if (easing) this.prevEasing = easing;
+    else easing = "045";
+
+    this.actions.push([properties, duration, easing]);
+
+    return this;
+
+  },
+
+  discard: function() {
+
+    this.manager.discard(this.context, this);
+
+    return this;
+
+  },
+
+  to: function(properties, duration, easing) {
+    return this.add(properties, duration, easing);
+  },
+
+  loop: function() {
+
+    this.looped = true;
+
+    return this;
+
+  },
+
+  repeat: function(times) {
+
+    this.actions.push(["repeat", times]);
+
+  },
+
+  wait: function(time) {
+
+    this.actions.push(["wait", time]);
+
+    return this;
+
+  },
+
+  delay: function(time) {
+
+    this.actions.push(["wait", time]);
+
+  },
+
+  stop: function() {
+
+    this.manager.remove(this);
+
+    return this;
+
+  },
+
+  play: function() {
+
+    this.manager.add(this);
+
+    this.finished = false;
+
+    return this;
+
+  },
+
+
+  end: function() {
+
+    var lastAnimationIndex = 0;
+
+    for (var i = this.index + 1; i < this.actions.length; i++) {
+      if (typeof this.actions[i][0] === "object") lastAnimationIndex = i;
+    }
+
+    this.index = lastAnimationIndex - 1;
+    this.next();
+    this.delta = this.duration;
+    this.step(0);
+
+    return this;
+
+  },
+
+  forward: function() {
+
+    this.delta = this.duration;
+    this.step(0);
+
+  },
+
+  rewind: function() {
+
+    this.delta = 0;
+    this.step(0);
+
+  },
+
+  next: function() {
+
+    this.delta = 0;
+
+    this.index++;
+
+    if (this.index >= this.actions.length) {
+
+      if (this.looped) {
+
+        this.trigger("loop", {
+          tween: this
+        });
+
+        this.index = 0;
+      } else {
+
+        this.trigger("finished", {
+          tween: this
+        });
+
+        this.finished = true;
+        this.manager.remove(this);
+        return;
+      }
+    }
+
+    this.current = this.actions[this.index];
+
+    if (this.current[0] === "wait") {
+
+      this.duration = this.current[1];
+      this.currentAction = "wait";
+
+    } else {
+
+      /* calculate changes */
+
+      var properties = this.current[0];
+
+      /* keep keys as array for 0.0001% performance boost */
+
+      this.keys = Object.keys(properties);
+
+      this.change = [];
+      this.before = [];
+      this.types = [];
+
+      for (i = 0; i < this.keys.length; i++) {
+        var key = this.keys[i];
+
+        if (typeof this.context[key] === "number") {
+          this.before.push(this.context[key]);
+          this.change.push(properties[key] - this.context[key]);
+          this.types.push(0);
+        } else {
+          var before = cq.color(this.context[key]);
+
+          this.before.push(before);
+
+          var after = cq.color(properties[key]);
+
+          var temp = [];
+
+          for (var j = 0; j < 3; j++) {
+            temp.push(after[j] - before[j]);
+          }
+
+          this.change.push(temp);
+
+          this.types.push(1);
+        }
+
+      }
+
+      this.currentAction = "animate";
+
+      this.duration = this.current[1];
+      this.easing = this.current[2];
+
+    }
+
+
+  },
+
+  prev: function() {
+
+  },
+
+  step: function(delta) {
+
+    this.delta += delta;
+
+    if (!this.current) this.next();
+
+    switch (this.currentAction) {
+
+      case "animate":
+        this.doAnimate(delta);
+        break;
+
+      case "wait":
+        this.doWait(delta);
+        break;
+
+    }
+
+  },
+
+  doAnimate: function(delta) {
+
+    this.progress = Math.min(1, this.delta / this.duration);
+
+    var mod = PLAYGROUND.Utils.ease(this.progress, this.easing);
+
+    for (var i = 0; i < this.keys.length; i++) {
+
+      var key = this.keys[i];
+
+      switch (this.types[i]) {
+
+        /* number */
+
+        case 0:
+
+          this.context[key] = this.before[i] + this.change[i] * mod;
+
+          break;
+
+          /* color */
+
+        case 1:
+
+          var change = this.change[i];
+          var before = this.before[i];
+          var color = [];
+
+          for (var j = 0; j < 3; j++) {
+            color.push(before[j] + change[j] * mod | 0);
+          }
+
+          this.context[key] = "rgb(" + color.join(",") + ")";
+
+          break;
+      }
+    }
+
+    if (this.progress >= 1) {
+      this.next();
+    }
+
+  },
+
+  doWait: function(delta) {
+
+    if (this.delta >= this.duration) this.next();
+
+  }
+
+};
+
+PLAYGROUND.Utils.extend(PLAYGROUND.Tween.prototype, PLAYGROUND.Events.prototype);
+
+PLAYGROUND.TweenManager = function(app) {
+
+  this.tweens = [];
+
+  if (app) {
+    this.app = app;
+    this.app.tween = this.tween.bind(this);
+  }
+
+  this.delta = 0;
+
+  this.app.on("step", this.step.bind(this));
+
+};
+
+PLAYGROUND.TweenManager.prototype = {
+
+  defaultEasing: "128",
+
+  discard: function(object, safe) {
+
+    for (var i = 0; i < this.tweens.length; i++) {
+      
+      var tween = this.tweens[i];
+
+      if(tween.context === object && tween !== safe) this.remove(tween);
+
+    }
+
+  },
+
+  tween: function(context) {
+
+    var tween = new PLAYGROUND.Tween(this, context);
+
+    this.add(tween);
+
+    return tween;
+
+  },
+ 
+  step: function(delta) {
+
+    this.delta += delta;
+
+    for (var i = 0; i < this.tweens.length; i++) {
+
+      var tween = this.tweens[i];
+
+      if (!tween._remove) tween.step(delta);
+      
+      if (tween._remove) this.tweens.splice(i--, 1);
+
+    }
+     
+  },
+
+  add: function(tween) {
+
+    tween._remove = false;
+
+    var index = this.tweens.indexOf(tween);
+
+    if (index === -1) this.tweens.push(tween);
+
+  },
+
+  remove: function(tween) {
+
+    tween._remove = true;
+
+  }
+
+};
+
+/* file: src/Atlases.js */
+
+PLAYGROUND.Application.prototype.loadAtlases = function() {
+
+  for (var i = 0; i < arguments.length; i++) {
+
+    var arg = arguments[i];
+
+    /* polymorphism at its finest */
+
+    if (typeof arg === "object") {
+
+      for (var key in arg) this.loadAtlases(arg[key]);
+
+    } else {
+
+      /* if argument is not an object/array let's try to load it */
+
+      this._loadAtlas(arg)
+
+    }
+  }
+
+};
+
+PLAYGROUND.Application.prototype.loadAtlas = function() {
+
+  return this.loadAtlases.apply(this, arguments);
+
+};
+
+PLAYGROUND.Application.prototype._loadAtlas = function(filename) {
+
+  var entry = this.getAssetEntry(filename, "atlases", "png");
+
+  this.loader.add(entry.url);
+
+  var atlas = this.atlases[entry.key] = {};
+
+  var image = atlas.image = new Image;
+
+  image.addEventListener("load", function() {
+    loader.success(entry.url);
+  });
+
+  image.addEventListener("error", function() {
+    loader.error(entry.url);
+  });
+
+  image.src = entry.url;
+
+  /* data */
+
+  var request = new XMLHttpRequest();
+
+  request.open("GET", entry.path + ".json", true);
+
+  this.loader.add(entry.path + ".json");
+
+  var loader = this.loader;
+
+  request.onload = function() {
+
+    var data = JSON.parse(this.response);
+
+    atlas.frames = [];
+
+    for (var i = 0; i < data.frames.length; i++) {
+      var frame = data.frames[i];
+
+      atlas.frames.push({
+        region: [frame.frame.x, frame.frame.y, frame.frame.w, frame.frame.h],
+        offset: [frame.spriteSourceSize.x || 0, frame.spriteSourceSize.y || 0],
+        width: frame.sourceSize.w,
+        height: frame.sourceSize.h
+      });
+    }
+
+    loader.success(entry.path + ".json");
+
+  }
+
+  request.send();
+};
+
+/* file: src/Fonts.js */
+
+PLAYGROUND.Application.prototype.loadFontOld = function(name) {
+
+  var styleNode = document.createElement("style");
+  styleNode.type = "text/css";
+
+  var formats = {
+    "woff": "woff",
+    "ttf": "truetype"
+  };
+
+  var sources = "";
+
+  for (var ext in formats) {
+    var type = formats[ext];
+    sources += " url(\"fonts/" + name + "." + ext + "\") format('" + type + "');"
+  }
+
+  styleNode.textContent = "@font-face { font-family: '" + name + "'; src: " + sources + " }";
+
+  document.head.appendChild(styleNode);
+
+  var layer = cq(32, 32);
+
+  layer.font("10px Testing");
+  layer.fillText(16, 16, 16).trim();
+
+  var width = layer.width;
+  var height = layer.height;
+
+  this.loader.add("font " + name);
+
+  var self = this;
+
+  function check() {
+
+    var layer = cq(32, 32);
+
+    layer.font("10px " + name).fillText(16, 16, 16);
+    layer.trim();
+
+    if (layer.width !== width || layer.height !== height) {
+
+      self.loader.ready("font " + name);
+
+    } else {
+
+      setTimeout(check, 250);
+
+    }
+
+  };
+
+  check();
+
+};
+
+/* file: src/DefaultState.js */
+
+PLAYGROUND.DefaultState = {
+
+};
+
+/* file: src/LoadingScreen.js */
+
+PLAYGROUND.LoadingScreen = {
+
+  /* basic loading screen using DOM */
+
+  logoRaw: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANoAAAASBAMAAADPiN0xAAAAGFBMVEUAAQAtLixHSUdnaGaJioimqKXMzsv7/fr5shgVAAAAAWJLR0QAiAUdSAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB98EAwkeA4oQWJ4AAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAB9klEQVQ4y72UvW+rMBDAz+FrpVKrrFmesmapWNOlrKjSe1kZ+uoVAvj+/frujG1SaJcqJwU7voOf7xMQzQmsIDi5NPTMsLRntH3U+F6SAZo3NlCvcgBFJz8o+vkDiE63lI95Y/UmpinsZWkgJWJiDbAVQ16htptxSTNloIlugwaw001Ey3ASF3so6L1qLNXzQS5S0UGKL/CI5wWNriE0UH9Yty37LqIVg+wsqu7Ix0MwVBSF/dU+jv2SNnma021LEdPqVnMeU3xAu0kXcSGjmq7Ox4E2Wn88LZ2+EFj3avjixzai6VPVyuYveZLHF2XfdDnvAq27DIHGuq+0DJFsE30OtB1KqOwd8Dr7PcM4b+jfj2g5lp4WyntBK66qua3JzEA+uXJpwH/NlVuzRVPY/kTLB2mjuN+KwdZ8FOy8j2gDbEUSqumnSCY4lf4ibq3IhVM4ycZQRnv+zFqVdJQVn6BxvUqebGpuaNo3sZxwBzjajiMZOoBiwyVF+kCr+nUaJOaGpnAeRPPJZTr4FqmHRXcneEo4DqQ/ftfdnLeDrUAME8xWKPeKCwW6YkEpXfs3p1EWJhdcUAYP0TI/uYaV8cgjwBovaeyWwji2T9rTFIdS/cP/MnkTLRUWxgNNZVin7bT5fqT9miDcUVJzR1gRpfIONMmulU+5Qqr6zXAUqAAAAABJRU5ErkJggg==",
+
+  create: function() {
+
+    var self = this;
+
+    this.logo = new Image;
+
+    this.logo.addEventListener("load", function() {
+      self.ready = true;
+      self.createElements();
+    });
+
+    this.logo.src = this.logoRaw;
+
+    this.background = "#000";
+
+    if (window.getComputedStyle) {
+      this.background = window.getComputedStyle(document.body).backgroundColor || "#000";
+    }
+
+
+  },
+
+  enter: function() {
+
+    this.current = 0;
+
+  },
+
+  leave: function() {
+
+    this.locked = true;
+
+    this.animation = this.app.tween(this)
+      .to({
+        current: 1
+      }, 0.5);
+
+  },
+
+  step: function(delta) {
+
+    if (this.locked) {
+
+      if (this.animation.finished) {
+        this.locked = false;
+        this.wrapper.parentNode.removeChild(this.wrapper);
+      }
+
+    } else {
+
+      this.current = this.current + Math.abs(this.app.loader.progress - this.current) * delta;
+    }
+
+  },
+
+  createElements: function() {
+
+    this.width = window.innerWidth * 0.6 | 0;
+    this.height = window.innerHeight * 0.1 | 0;
+
+    this.wrapper = document.createElement("div");
+    this.wrapper.style.width = this.width + "px";
+    this.wrapper.style.height = this.height + "px";
+    this.wrapper.style.background = "#000";
+    this.wrapper.style.border = "4px solid #fff";
+    this.wrapper.style.position = "absolute";
+    this.wrapper.style.left = (window.innerWidth / 2 - this.width / 2 | 0) + "px";
+    this.wrapper.style.top = (window.innerHeight / 2 - this.height / 2 | 0) + "px";
+    this.wrapper.style.zIndex = 100;
+
+    this.app.container.appendChild(this.wrapper);
+
+    this.progressBar = document.createElement("div");
+    this.progressBar.style.width = "0%";
+    this.progressBar.style.height = this.height + "px";
+    this.progressBar.style.background = "#fff";
+
+    this.wrapper.appendChild(this.progressBar);
+
+  },
+
+
+  render: function() {
+
+    if (!this.ready) return;
+
+    this.progressBar.style.width = (this.current * 100 | 0) + "%";
+
+
+  }
+
+};
+
+/* file: src/lib/CanvasQuery.js */
+
+/*     
+
+  Canvas Query r4
+  
+  http://canvasquery.com
+  
+  (c) 2012-2015 http://rezoner.net
+  
+  Canvas Query may be freely distributed under the MIT license.
+
+
+
+  ! fixed: leaking arguments in fastApply bailing out optimization 
+  + cacheText
+  + compare
+
+*/
+
+
+(function() {
+
+  var COCOONJS = false;
+
+  var Canvas = window.HTMLCanvasElement;
+  var Image = window.HTMLImageElement;
+  var COCOONJS = navigator.isCocoonJS;
+
+  var cq = function(selector) {
+    if (arguments.length === 0) {
+      var canvas = cq.createCanvas(window.innerWidth, window.innerHeight);
+      window.addEventListener("resize", function() {
+        // canvas.width = window.innerWidth;
+        // canvas.height = window.innerHeight;
+      });
+    } else if (typeof selector === "string") {
+      var canvas = document.querySelector(selector);
+    } else if (typeof selector === "number") {
+      var canvas = cq.createCanvas(arguments[0], arguments[1]);
+    } else if (selector instanceof Image) {
+      var canvas = cq.createCanvas(selector);
+    } else if (selector instanceof cq.Layer) {
+      return selector;
+    } else {
+      var canvas = selector;
+    }
+
+    return new cq.Layer(canvas);
+  };
+
+  cq.lineSpacing = 1.0;
+  cq.defaultFont = "Arial";
+
+  cq.palettes = {
+
+    db16: ["#140c1c", "#442434", "#30346d", "#4e4a4e", "#854c30", "#346524", "#d04648", "#757161", "#597dce", "#d27d2c", "#8595a1", "#6daa2c", "#d2aa99", "#6dc2ca", "#dad45e", "#deeed6"],
+    db32: ["#000000", "#222034", "#45283c", "#663931", "#8f563b", "#df7126", "#d9a066", "#eec39a", "#fbf236", "#99e550", "#6abe30", "#37946e", "#4b692f", "#524b24", "#323c39", "#3f3f74", "#306082", "#5b6ee1", "#639bff", "#5fcde4", "#cbdbfc", "#ffffff", "#9badb7", "#847e87", "#696a6a", "#595652", "#76428a", "#ac3232", "#d95763", "#d77bba", "#8f974a", "#8a6f30"],
+    c64: ["#000000", "#6a5400", "#68ae5c", "#8a8a8a", "#adadad", "#636363", "#c37b75", "#c9d684", "#ffffff", "#984b43", "#a3e599", "#79c1c8", "#9b6739", "#9b51a5", "#52429d", "#8a7bce"],
+    gameboy: ["#0f380f", "#306230", "#8bac0f", "#9bbc0f"],
+    sega: ["#000000", "#555500", "#005500", "#555555", "#55aa00", "#550000", "#aaffaa", "#aaaaaa", "#ff5555", "#005555", "#550055", "#aaaa55", "#ffffaa", "#aa5555", "#ffaa55", "#ffff55", "#ffffff", "#ffaaaa", "#000055", "#55aaaa", "#aa0000", "#ff5500", "#ffaa00", "#aa5500", "#ff0000", "#ffaaff", "#aa55aa", "#aaaa00", "#aaff00", "#aaaaff", "#5555aa", "#aaffff"],
+    cga: ["#000000", "#ff5555", "#55ff55", "#ffff55"],
+    nes: ["#7C7C7C", "#0000FC", "#0000BC", "#4428BC", "#940084", "#A80020", "#A81000", "#881400", "#503000", "#007800", "#006800", "#005800", "#004058", "#000000", "#000000", "#000000", "#BCBCBC", "#0078F8", "#0058F8", "#6844FC", "#D800CC", "#E40058", "#F83800", "#E45C10", "#AC7C00", "#00B800", "#00A800", "#00A844", "#008888", "#000000", "#000000", "#000000", "#F8F8F8", "#3CBCFC", "#6888FC", "#9878F8", "#F878F8", "#F85898", "#F87858", "#FCA044", "#F8B800", "#B8F818", "#58D854", "#58F898", "#00E8D8", "#787878", "#000000", "#000000", "#FCFCFC", "#A4E4FC", "#B8B8F8", "#D8B8F8", "#F8B8F8", "#F8A4C0", "#F0D0B0", "#FCE0A8", "#F8D878", "#D8F878", "#B8F8B8", "#B8F8D8", "#00FCFC", "#F8D8F8", "#000000"],
+
+  };
+
+  cq.cocoon = function(selector) {
+    if (arguments.length === 0) {
+      var canvas = cq.createCocoonCanvas(window.innerWidth, window.innerHeight);
+      window.addEventListener("resize", function() {});
+    } else if (typeof selector === "string") {
+      var canvas = document.querySelector(selector);
+    } else if (typeof selector === "number") {
+      var canvas = cq.createCocoonCanvas(arguments[0], arguments[1]);
+    } else if (selector instanceof Image) {
+      var canvas = cq.createCocoonCanvas(selector);
+    } else if (selector instanceof cq.Layer) {
+      return selector;
+    } else {
+      var canvas = selector;
+    }
+
+    return new cq.Layer(canvas);
+  }
+
+
+  cq.extend = function() {
+    for (var i = 1; i < arguments.length; i++) {
+      for (var j in arguments[i]) {
+        arguments[0][j] = arguments[i][j];
+      }
+    }
+
+    return arguments[0];
+  };
+
+  cq.augment = function() {
+    for (var i = 1; i < arguments.length; i++) {
+      _.extend(arguments[0], arguments[i]);
+      arguments[i](arguments[0]);
+    }
+  };
+
+  cq.distance = function(x1, y1, x2, y2) {
+    if (arguments.length > 2) {
+      var dx = x1 - x2;
+      var dy = y1 - y2;
+
+      return Math.sqrt(dx * dx + dy * dy);
+    } else {
+      return Math.abs(x1 - y1);
+    }
+  };
+
+  /* fast.js */
+
+  cq.fastApply = function(subject, thisContext, args) {
+
+    switch (args.length) {
+      case 0:
+        return subject.call(thisContext);
+      case 1:
+        return subject.call(thisContext, args[0]);
+      case 2:
+        return subject.call(thisContext, args[0], args[1]);
+      case 3:
+        return subject.call(thisContext, args[0], args[1], args[2]);
+      case 4:
+        return subject.call(thisContext, args[0], args[1], args[2], args[3]);
+      case 5:
+        return subject.call(thisContext, args[0], args[1], args[2], args[3], args[4]);
+      case 6:
+        return subject.call(thisContext, args[0], args[1], args[2], args[3], args[4], args[5]);
+      case 7:
+        return subject.call(thisContext, args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
+      case 8:
+        return subject.call(thisContext, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);
+      case 9:
+        return subject.call(thisContext, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]);
+      default:
+        return subject.apply(thisContext, args);
+    }
+
+  };
+
+  cq.extend(cq, {
+
+    smoothing: true,
+
+    blend: function(below, above, mode, mix) {
+
+      if (typeof mix === "undefined") mix = 1;
+
+      var below = cq(below);
+      var mask = below.clone();
+      var above = cq(above);
+
+      below.save();
+      below.globalAlpha(mix);
+      below.globalCompositeOperation(mode);
+      below.drawImage(above.canvas, 0, 0);
+      below.restore();
+
+      mask.save();
+      mask.globalCompositeOperation("source-in");
+      mask.drawImage(below.canvas, 0, 0);
+      mask.restore();
+
+      return mask;
+    },
+
+    matchColor: function(color, palette) {
+      var rgbPalette = [];
+
+      for (var i = 0; i < palette.length; i++) {
+        rgbPalette.push(cq.color(palette[i]));
+      }
+
+      var imgData = cq.color(color);
+
+      var difList = [];
+      for (var j = 0; j < rgbPalette.length; j++) {
+        var rgbVal = rgbPalette[j];
+        var rDif = Math.abs(imgData[0] - rgbVal[0]),
+          gDif = Math.abs(imgData[1] - rgbVal[1]),
+          bDif = Math.abs(imgData[2] - rgbVal[2]);
+        difList.push(rDif + gDif + bDif);
+      }
+
+      var closestMatch = 0;
+      for (var j = 0; j < palette.length; j++) {
+        if (difList[j] < difList[closestMatch]) {
+          closestMatch = j;
+        }
+      }
+
+      return palette[closestMatch];
+    },
+
+    temp: function(width, height) {
+      if (!this.tempLayer) {
+        this.tempLayer = cq(1, 1);
+      }
+
+      if (width instanceof Image) {
+        this.tempLayer.width = width.width;
+        this.tempLayer.height = width.height;
+        this.tempLayer.context.drawImage(width, 0, 0);
+      } else if (width instanceof Canvas) {
+        this.tempLayer.width = width.width;
+        this.tempLayer.height = width.height;
+        this.tempLayer.context.drawImage(width, 0, 0);
+      } else if (width instanceof CanvasQuery.Layer) {
+        this.tempLayer.width = width.width;
+        this.tempLayer.height = width.height;
+        this.tempLayer.context.drawImage(width.canvas, 0, 0);
+      } else {
+        this.tempLayer.width = width;
+        this.tempLayer.height = height;
+      }
+
+      return this.tempLayer;
+    },
+
+    wrapValue: function(value, min, max) {
+      if (value < min) return max + (value % max);
+      if (value >= max) return value % max;
+      return value;
+    },
+
+    limitValue: function(value, min, max) {
+      return value < min ? min : value > max ? max : value;
+    },
+
+    mix: function(a, b, amount) {
+      return a + (b - a) * amount;
+    },
+
+    hexToRgb: function(hex) {
+      if (hex.length === 7) return ['0x' + hex[1] + hex[2] | 0, '0x' + hex[3] + hex[4] | 0, '0x' + hex[5] + hex[6] | 0];
+      else return ['0x' + hex[1] + hex[1] | 0, '0x' + hex[2] + hex[2] | 0, '0x' + hex[3] + hex[3] | 0];
+    },
+
+    rgbToHex: function(r, g, b) {
+      return "#" + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1, 7);
+    },
+
+    extractCanvas: function(o) {
+
+      if (o.canvas) return o.canvas;
+      else return o;
+
+    },
+
+    compare: function(a, b) {
+
+      a = this.extractCanvas(a);
+      b = this.extractCanvas(b);
+
+      a = a.getContext("2d").getImageData(0, 0, a.width, a.height).data;
+      b = b.getContext("2d").getImageData(0, 0, b.width, b.height).data;
+
+      if (a.length !== b.length) return false;
+
+      for (var i = 0; i < a.length; i++) {
+
+        if (a[i] !== b[i]) return false;
+
+      }
+
+      return true;
+
+    },
+
+    /* author: http://mjijackson.com/ */
+
+    rgbToHsl: function(r, g, b) {
+
+      if (r instanceof Array) {
+        b = r[2];
+        g = r[1];
+        r = r[0];
+      }
+
+      r /= 255, g /= 255, b /= 255;
+      var max = Math.max(r, g, b),
+        min = Math.min(r, g, b);
+      var h, s, l = (max + min) / 2;
+
+      if (max == min) {
+        h = s = 0; // achromatic
+      } else {
+        var d = max - min;
+        s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+        switch (max) {
+          case r:
+            h = (g - b) / d + (g < b ? 6 : 0);
+            break;
+          case g:
+            h = (b - r) / d + 2;
+            break;
+          case b:
+            h = (r - g) / d + 4;
+            break;
+        }
+        h /= 6;
+      }
+
+      return [h, s, l];
+    },
+
+    /* author: http://mjijackson.com/ */
+
+    hue2rgb: function(p, q, t) {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    },
+
+    hslToRgb: function(h, s, l) {
+      var r, g, b;
+
+      if (s == 0) {
+        r = g = b = l; // achromatic
+      } else {
+
+        var q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+        var p = 2 * l - q;
+        r = this.hue2rgb(p, q, h + 1 / 3);
+        g = this.hue2rgb(p, q, h);
+        b = this.hue2rgb(p, q, h - 1 / 3);
+      }
+
+      return [r * 255 | 0, g * 255 | 0, b * 255 | 0];
+    },
+
+    rgbToHsv: function(r, g, b) {
+      if (r instanceof Array) {
+        b = r[2];
+        g = r[1];
+        r = r[0];
+      }
+
+      r = r / 255, g = g / 255, b = b / 255;
+      var max = Math.max(r, g, b),
+        min = Math.min(r, g, b);
+      var h, s, v = max;
+
+      var d = max - min;
+      s = max == 0 ? 0 : d / max;
+
+      if (max == min) {
+        h = 0; // achromatic
+      } else {
+        switch (max) {
+          case r:
+            h = (g - b) / d + (g < b ? 6 : 0);
+            break;
+          case g:
+            h = (b - r) / d + 2;
+            break;
+          case b:
+            h = (r - g) / d + 4;
+            break;
+        }
+        h /= 6;
+      }
+
+      return [h, s, v];
+    },
+
+    hsvToRgb: function(h, s, v) {
+      var r, g, b;
+
+      var i = Math.floor(h * 6);
+      var f = h * 6 - i;
+      var p = v * (1 - s);
+      var q = v * (1 - f * s);
+      var t = v * (1 - (1 - f) * s);
+
+      switch (i % 6) {
+        case 0:
+          r = v, g = t, b = p;
+          break;
+        case 1:
+          r = q, g = v, b = p;
+          break;
+        case 2:
+          r = p, g = v, b = t;
+          break;
+        case 3:
+          r = p, g = q, b = v;
+          break;
+        case 4:
+          r = t, g = p, b = v;
+          break;
+        case 5:
+          r = v, g = p, b = q;
+          break;
+      }
+
+      return [r * 255, g * 255, b * 255];
+    },
+
+    color: function() {
+      var result = new cq.Color();
+      result.parse(arguments[0], arguments[1]);
+      return result;
+    },
+
+    poolArray: [],
+
+    pool: function() {
+
+      if (!this.poolArray.length) {
+        for (var i = 0; i < 100; i++) {
+          this.poolArray.push(this.createCanvas(1, 1));
+        }
+      }
+
+      return this.poolArray.pop();
+
+    },
+
+    reuse: function(object) {
+
+      return this.recycle(object);
+
+    },
+
+    recycle: function(object) {
+
+      if (object instanceof CanvasQuery.Layer) {
+
+        this.poolArray.push(object.canvas);
+
+      } else {
+
+        this.poolArray.push(object);
+
+      }
+
+    },
+
+    createCanvas: function(width, height) {
+      var result = document.createElement("canvas");
+
+      if (arguments[0] instanceof Image || arguments[0] instanceof Canvas) {
+        var image = arguments[0];
+        result.width = image.width;
+        result.height = image.height;
+        result.getContext("2d").drawImage(image, 0, 0);
+      } else {
+        result.width = width;
+        result.height = height;
+      }
+
+
+      return result;
+    },
+
+    createCocoonCanvas: function(width, height) {
+      var result = document.createElement("screencanvas");
+
+      if (arguments[0] instanceof Image) {
+        var image = arguments[0];
+        result.width = image.width;
+        result.height = image.height;
+        result.getContext("2d").drawImage(image, 0, 0);
+      } else {
+        result.width = width;
+        result.height = height;
+      }
+
+      return result;
+    },
+
+    createImageData: function(width, height) {
+      return cq.createCanvas(width, height).getContext("2d").createImageData(width, height);
+    }
+
+  });
+
+  cq.Layer = function(canvas) {
+    this.context = canvas.getContext("2d");
+    this.canvas = canvas;
+    this.alignX = 0;
+    this.alignY = 0;
+    this.aligned = false;
+    this.update();
+  };
+
+  cq.Layer.prototype = {
+
+    constructor: cq.Layer,
+
+    update: function() {
+
+      var smoothing = cq.smoothing;
+
+      if (typeof this.smoothing !== "undefined") smoothing = this.smoothing;
+
+      this.context.webkitImageSmoothingEnabled = smoothing;
+      this.context.mozImageSmoothingEnabled = smoothing;
+      this.context.msImageSmoothingEnabled = smoothing;
+      this.context.imageSmoothingEnabled = smoothing;
+
+      if (COCOONJS) Cocoon.Utils.setAntialias(smoothing);
+    },
+
+    appendTo: function(selector) {
+      if (typeof selector === "object") {
+        var element = selector;
+      } else {
+        var element = document.querySelector(selector);
+      }
+
+      element.appendChild(this.canvas);
+
+      return this;
+    },
+
+    a: function(a) {
+      if (arguments.length) {
+        this.previousAlpha = this.globalAlpha();
+        return this.globalAlpha(a);
+      } else
+        return this.globalAlpha();
+    },
+
+    ra: function() {
+      return this.a(this.previousAlpha);
+    },
+    /*
+        drawImage: function() {
+
+          if (!this.alignX && !this.alignY) {
+            this.context.call
+          }
+
+            return this;
+
+
+        },
+
+        restore: function() {
+          this.context.restore();
+          this.alignX = 0;
+          this.alignY = 0;
+        },
+        */
+
+    realign: function() {
+
+      this.alignX = this.prevAlignX;
+      this.alignY = this.prevAlignY;
+
+      return this;
+
+    },
+
+    align: function(x, y) {
+
+      if (typeof y === "undefined") y = x;
+
+      this.alignX = x;
+      this.alignY = y;
+
+      return this;
+    },
+
+
+    /* save translate align rotate scale */
+
+    stars: function(x, y, alignX, alignY, rotation, scaleX, scaleY) {
+
+      if (typeof alignX === "undefined") alignX = 0.5;
+      if (typeof alignY === "undefined") alignY = 0.5;
+      if (typeof rotation === "undefined") rotation = 0;
+      if (typeof scaleX === "undefined") scaleX = 1.0;
+      if (typeof scaleY === "undefined") scaleY = scaleX;
+
+      this.save();
+      this.translate(x, y);
+      this.align(alignX, alignY);
+      this.rotate(rotation);
+      this.scale(scaleX, scaleY);
+
+      return this;
+    },
+
+    tars: function(x, y, alignX, alignY, rotation, scaleX, scaleY) {
+
+      if (typeof alignX === "undefined") alignX = 0.5;
+      if (typeof alignY === "undefined") alignY = 0.5;
+      if (typeof rotation === "undefined") rotation = 0;
+      if (typeof scaleX === "undefined") scaleX = 1.0;
+      if (typeof scaleY === "undefined") scaleY = scaleX;
+
+      this.translate(x, y);
+      this.align(alignX, alignY);
+      this.rotate(rotation);
+      this.scale(scaleX, scaleY);
+
+      return this;
+
+    },
+
+    fillRect: function() {
+
+      if (this.alignX || this.alignY) {
+        this.context.fillRect(arguments[0] - arguments[2] * this.alignX | 0, arguments[1] - arguments[3] * this.alignY | 0, arguments[2], arguments[3]);
+      } else {
+        this.context.fillRect(arguments[0], arguments[1], arguments[2], arguments[3]);
+      }
+
+      // cq.fastApply(this.context.fillRect, this.context, arguments);
+
+      return this;
+
+    },
+
+    strokeRect: function() {
+
+      if (this.alignX || this.alignY) {
+        this.context.strokeRect(arguments[0] - arguments[2] * this.alignX | 0, arguments[1] - arguments[3] * this.alignY | 0, arguments[2], arguments[3]);
+      } else {
+        this.context.strokeRect(arguments[0], arguments[1], arguments[2], arguments[3]);
+      }
+
+      // cq.fastApply(this.context.strokeRect, this.context, arguments);
+
+      return this;
+
+    },
+
+    drawImage: function(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight) {
+
+      if (this.alignX || this.alignY) {
+
+        if (sWidth == null) {
+          sx -= image.width * this.alignX | 0;
+          sy -= image.height * this.alignY | 0;
+        } else {
+          dx -= dWidth * this.alignX | 0;
+          dy -= dHeight * this.alignY | 0;
+        }
+
+      }
+
+      if (sWidth == null) {
+
+        this.context.drawImage(image, sx, sy);
+
+      } else if (dx == null) {
+
+        this.context.drawImage(image, sx, sy, sWidth, sHeight);
+
+      } else {
+
+        this.context.drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
+
+      }
+
+      // cq.fastApply(this.context.drawImage, this.context, arguments);
+
+      return this;
+
+    },
+
+    save: function() {
+
+      this.prevAlignX = this.alignX;
+      this.prevAlignY = this.alignY;
+
+      this.context.save();
+
+      return this;
+
+    },
+
+    restore: function() {
+
+      this.realign();
+      this.context.restore();
+
+      return this;
+
+    },
+
+    drawTile: function(image, x, y, frameX, frameY, frameWidth, frameHeight, frames, frame) {
+
+    },
+
+    drawAtlasFrame: function(atlas, frame, x, y) {
+
+      var frame = atlas.frames[frame];
+
+      this.drawRegion(
+        atlas.image,
+        frame.region,
+        x - frame.width * this.alignX + frame.offset[0] + frame.region[2] * this.alignX,
+        y - frame.height * this.alignY + frame.offset[1] + frame.region[3] * this.alignY
+      );
+
+      return this;
+
+    },
+
+
+    imageFill: function(image, width, height) {
+
+      var scale = Math.max(width / image.width, height / image.height);
+
+      this.save();
+      this.scale(scale, scale);
+      this.drawImage(image, 0, 0);
+      this.restore();
+
+    },
+
+    drawRegion: function(image, region, x, y, scale) {
+      scale = scale || 1;
+
+      return this.drawImage(
+        image, region[0], region[1], region[2], region[3],
+        x | 0, y | 0, region[2] * scale | 0, region[3] * scale | 0
+      );
+    },
+
+    cache: function() {
+      return this.clone().canvas;
+
+      /* FFS .... image.src is no longer synchronous when assigning dataURL */
+
+      var image = new Image;
+      image.src = this.canvas.toDataURL();
+      return image;
+    },
+
+    blendOn: function(what, mode, mix) {
+      cq.blend(what, this, mode, mix);
+
+      return this;
+    },
+
+    posterize: function(pc, inc) {
+      pc = pc || 32;
+      inc = inc || 4;
+      var imgdata = this.getImageData(0, 0, this.width, this.height);
+      var data = imgdata.data;
+
+      for (var i = 0; i < data.length; i += inc) {
+        data[i] -= data[i] % pc; // set value to nearest of 8 possibilities
+        data[i + 1] -= data[i + 1] % pc; // set value to nearest of 8 possibilities
+        data[i + 2] -= data[i + 2] % pc; // set value to nearest of 8 possibilities
+      }
+
+      this.putImageData(imgdata, 0, 0); // put image data to canvas
+
+      return this;
+    },
+
+
+    bw: function(pc) {
+      pc = 128;
+      var imgdata = this.getImageData(0, 0, this.width, this.height);
+      var data = imgdata.data;
+      // 8-bit: rrr ggg bb
+      for (var i = 0; i < data.length; i += 4) {
+        var v = ((data[i] + data[i + 1] + data[i + 2]) / 3);
+
+        v = (v / 128 | 0) * 128;
+        //data[i] = v; // set value to nearest of 8 possibilities
+        //data[i + 1] = v; // set value to nearest of 8 possibilities
+        data[i + 2] = (v / 255) * data[i]; // set value to nearest of 8 possibilities
+
+      }
+
+      this.putImageData(imgdata, 0, 0); // put image data to canvas
+    },
+
+    blend: function(what, mode, mix) {
+      if (typeof what === "string") {
+        var color = what;
+        what = cq(this.canvas.width, this.canvas.height);
+        what.fillStyle(color).fillRect(0, 0, this.canvas.width, this.canvas.height);
+      }
+
+      var result = cq.blend(this, what, mode, mix);
+
+      this.canvas = result.canvas;
+      this.context = result.context;
+
+      return this;
+    },
+
+    textWithBackground: function(text, x, y, background, padding) {
+      var w = this.measureText(text).width;
+      var h = this.fontHeight() * 0.8;
+      var f = this.fillStyle();
+      var padding = padding || 2;
+
+      this.fillStyle(background).fillRect(x - w / 2 - padding * 2, y - padding, w + padding * 4, h + padding * 2)
+      this.fillStyle(f).textAlign("center").textBaseline("top").fillText(text, x, y);
+
+      return this;
+    },
+
+    fillCircle: function(x, y, r) {
+      this.context.beginPath();
+      this.context.arc(x, y, r, 0, Math.PI * 2);
+      this.context.fill();
+      return this;
+    },
+
+    strokeCircle: function(x, y, r) {
+      this.context.beginPath();
+      this.context.arc(x, y, r, 0, Math.PI * 2);
+      this.context.stroke();
+      return this;
+    },
+
+    circle: function(x, y, r) {
+      this.context.beginPath();
+      this.context.arc(x, y, r, 0, Math.PI * 2);
+      return this;
+    },
+
+    crop: function(x, y, w, h) {
+
+      if (arguments.length === 1) {
+
+        var y = arguments[0][1];
+        var w = arguments[0][2];
+        var h = arguments[0][3];
+        var x = arguments[0][0];
+      }
+
+      var canvas = cq.createCanvas(w, h);
+      var context = canvas.getContext("2d");
+
+      context.drawImage(this.canvas, x, y, w, h, 0, 0, w, h);
+      this.canvas.width = w;
+      this.canvas.height = h;
+      this.clear();
+      this.context.drawImage(canvas, 0, 0);
+
+      return this;
+    },
+
+    set: function(properties) {
+      cq.extend(this.context, properties);
+    },
+
+    resize: function(width, height) {
+      var w = width,
+        h = height;
+
+      if (arguments.length === 1) {
+
+        w = arguments[0] * this.canvas.width | 0;
+        h = arguments[0] * this.canvas.height | 0;
+
+      } else {
+
+        if (height === false) {
+
+          if (this.canvas.width > width) {
+            h = this.canvas.height * (width / this.canvas.width) | 0;
+            w = width;
+          } else {
+            w = this.canvas.width;
+            h = this.canvas.height;
+          }
+
+        } else if (width === false) {
+
+          if (this.canvas.width > width) {
+            w = this.canvas.width * (height / this.canvas.height) | 0;
+            h = height;
+          } else {
+            w = this.canvas.width;
+            h = this.canvas.height;
+          }
+
+        }
+
+      }
+
+      var cqresized = cq(w, h).drawImage(this.canvas, 0, 0, this.canvas.width, this.canvas.height, 0, 0, w, h);
+
+      this.canvas = cqresized.canvas;
+      this.context = cqresized.context;
+
+      return this;
+    },
+
+    imageLine: function(image, region, x, y, ex, ey, scale) {
+      if (!region) region = [0, 0, image.width, image.height];
+
+      var distance = cq.distance(x, y, ex, ey);
+      var count = distance / region[3] + 0.5 | 0;
+      var angle = Math.atan2(ey - y, ex - x) + Math.PI / 2;
+
+      this.save();
+
+      this.translate(x, y);
+      this.rotate(angle);
+
+      if (scale) this.scale(scale, 1.0);
+
+      for (var i = 0; i <= count; i++) {
+        this.drawRegion(image, region, -region[2] / 2 | 0, -region[3] * (i + 1));
+      }
+
+      this.restore();
+
+      return this;
+    },
+
+    trim: function(color, changes) {
+      var transparent;
+
+      if (color) {
+        color = cq.color(color).toArray();
+        transparent = !color[3];
+      } else transparent = true;
+
+      var sourceData = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
+      var sourcePixels = sourceData.data;
+
+      var bound = [this.canvas.width, this.canvas.height, 0, 0];
+
+      var width = this.canvas.width;
+      var height = this.canvas.height;
+
+      for (var i = 0, len = sourcePixels.length; i < len; i += 4) {
+        if (transparent) {
+          if (!sourcePixels[i + 3]) continue;
+        } else if (sourcePixels[i + 0] === color[0] && sourcePixels[i + 1] === color[1] && sourcePixels[i + 2] === color[2]) continue;
+
+        var x = (i / 4 | 0) % this.canvas.width | 0;
+        var y = (i / 4 | 0) / this.canvas.width | 0;
+
+        if (x < bound[0]) bound[0] = x;
+        if (x > bound[2]) bound[2] = x;
+
+        if (y < bound[1]) bound[1] = y;
+        if (y > bound[3]) bound[3] = y;
+      }
+
+
+      if (bound[2] === 0 && bound[3] === 0) {} else {
+        if (changes) {
+          changes.left = bound[0];
+          changes.top = bound[1];
+
+          changes.bottom = height - bound[3];
+          changes.right = width - bound[2] - bound[0];
+
+          changes.width = bound[2] - bound[0];
+          changes.height = bound[3] - bound[1];
+        }
+
+        this.crop(bound[0], bound[1], bound[2] - bound[0] + 1, bound[3] - bound[1] + 1);
+      }
+
+      return this;
+    },
+
+    matchPalette: function(palette) {
+
+      var imgData = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
+
+      var rgbPalette = [];
+
+      for (var i = 0; i < palette.length; i++) {
+
+        rgbPalette.push(cq.color(palette[i]));
+
+      }
+
+      for (var i = 0; i < imgData.data.length; i += 4) {
+
+        var difList = [];
+
+        if (!imgData.data[i + 3]) continue;
+
+        for (var j = 0; j < rgbPalette.length; j++) {
+          var rgbVal = rgbPalette[j];
+          var rDif = Math.abs(imgData.data[i] - rgbVal[0]),
+            gDif = Math.abs(imgData.data[i + 1] - rgbVal[1]),
+            bDif = Math.abs(imgData.data[i + 2] - rgbVal[2]);
+          difList.push(rDif + gDif + bDif);
+        }
+
+        var closestMatch = 0;
+
+        for (var j = 0; j < palette.length; j++) {
+          if (difList[j] < difList[closestMatch]) {
+            closestMatch = j;
+          }
+        }
+
+        var paletteRgb = cq.hexToRgb(palette[closestMatch]);
+        imgData.data[i] = paletteRgb[0];
+        imgData.data[i + 1] = paletteRgb[1];
+        imgData.data[i + 2] = paletteRgb[2];
+
+        /* dithering */
+
+        //imgData.data[i + 3] = (255 * Math.random() < imgData.data[i + 3]) ? 255 : 0;
+
+        //imgData.data[i + 3] = imgData.data[i + 3] > 128 ? 255 : 0;
+        /*
+        if (i % 3 === 0) {
+          imgData.data[i] -= cq.limitValue(imgData.data[i] - 50, 0, 255);
+          imgData.data[i + 1] -= cq.limitValue(imgData.data[i + 1] - 50, 0, 255);
+          imgData.data[i + 2] -= cq.limitValue(imgData.data[i + 2] - 50, 0, 255);
+        }
+        */
+
+      }
+
+      this.context.putImageData(imgData, 0, 0);
+
+      return this;
+
+    },
+
+    getPalette: function() {
+      var palette = [];
+      var sourceData = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
+      var sourcePixels = sourceData.data;
+
+      for (var i = 0, len = sourcePixels.length; i < len; i += 4) {
+        if (sourcePixels[i + 3]) {
+          var hex = cq.rgbToHex(sourcePixels[i + 0], sourcePixels[i + 1], sourcePixels[i + 2]);
+          if (palette.indexOf(hex) === -1) palette.push(hex);
+        }
+      }
+
+      return palette;
+    },
+
+    mapPalette: function() {
+
+    },
+
+
+    polygon: function(array, x, y) {
+
+      this.beginPath();
+
+      this.moveTo(array[0][0] + x, array[0][1] + y);
+
+      for (var i = 1; i < array.length; i++) {
+        this.lineTo(array[i][0] + x, array[i][1] + y);
+      }
+
+      this.closePath();
+
+      return this;
+    },
+
+    fillPolygon: function(polygon) {
+      this.beginPath();
+      this.polygon(polygon);
+      this.fill();
+    },
+
+    strokePolygon: function(polygon) {
+      this.beginPath();
+      this.polygon(polygon);
+      this.stroke();
+    },
+
+    colorToMask: function(color, inverted) {
+      color = cq.color(color).toArray();
+      var sourceData = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
+      var sourcePixels = sourceData.data;
+
+      var mask = [];
+
+      for (var i = 0, len = sourcePixels.length; i < len; i += 4) {
+        if (sourcePixels[i + 3] > 0) mask.push(inverted ? false : true);
+        else mask.push(inverted ? true : false);
+      }
+
+      return mask;
+    },
+
+    grayscaleToMask: function() {
+
+      var sourceData = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
+      var sourcePixels = sourceData.data;
+
+      var mask = [];
+
+      for (var i = 0, len = sourcePixels.length; i < len; i += 4) {
+        mask.push(((sourcePixels[i + 0] + sourcePixels[i + 1] + sourcePixels[i + 2]) / 3) / 255);
+      }
+
+      return mask;
+    },
+
+    applyMask: function(mask) {
+      var sourceData = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
+      var sourcePixels = sourceData.data;
+
+      var mode = typeof mask[0] === "boolean" ? "bool" : "byte";
+
+      for (var i = 0, len = sourcePixels.length; i < len; i += 4) {
+        var value = mask[i / 4];
+        sourcePixels[i + 3] = value * 255 | 0;
+      }
+
+      this.context.putImageData(sourceData, 0, 0);
+      return this;
+    },
+
+    fillMask: function(mask) {
+
+      var sourceData = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
+      var sourcePixels = sourceData.data;
+
+      var maskType = typeof mask[0] === "boolean" ? "bool" : "byte";
+      var colorMode = arguments.length === 2 ? "normal" : "gradient";
+
+      var color = cq.color(arguments[1]);
+      if (colorMode === "gradient") colorB = cq.color(arguments[2]);
+
+      for (var i = 0, len = sourcePixels.length; i < len; i += 4) {
+        var value = mask[i / 4];
+
+        if (maskType === "byte") value /= 255;
+
+        if (colorMode === "normal") {
+          if (value) {
+            sourcePixels[i + 0] = color[0] | 0;
+            sourcePixels[i + 1] = color[1] | 0;
+            sourcePixels[i + 2] = color[2] | 0;
+            sourcePixels[i + 3] = value * 255 | 0;
+          }
+        } else {
+          sourcePixels[i + 0] = color[0] + (colorB[0] - color[0]) * value | 0;
+          sourcePixels[i + 1] = color[1] + (colorB[1] - color[1]) * value | 0;
+          sourcePixels[i + 2] = color[2] + (colorB[2] - color[2]) * value | 0;
+          sourcePixels[i + 3] = 255;
+        }
+      }
+
+      this.context.putImageData(sourceData, 0, 0);
+      return this;
+    },
+
+    clear: function(color) {
+      if (color) {
+        this.context.fillStyle = color;
+        this.context.fillRect(0, 0, this.canvas.width, this.canvas.height);
+      } else {
+        this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+      }
+
+      return this;
+    },
+
+    clone: function() {
+
+      // var result = cq.createCanvas(this.canvas);
+
+      var result = cq.pool();
+      result.width = this.width;
+      result.height = this.height;
+      result.getContext("2d").drawImage(this.canvas, 0, 0);
+
+      return cq(result);
+    },
+
+    gradientText: function(text, x, y, maxWidth, gradient) {
+
+      var words = text.split(" ");
+
+      var h = this.fontHeight() * 2;
+
+      var ox = 0;
+      var oy = 0;
+
+      if (maxWidth) {
+        var line = 0;
+        var lines = [""];
+
+        for (var i = 0; i < words.length; i++) {
+          var word = words[i] + " ";
+          var wordWidth = this.context.measureText(word).width;
+
+          if (ox + wordWidth > maxWidth) {
+            lines[++line] = "";
+            ox = 0;
+          }
+
+          lines[line] += word;
+
+          ox += wordWidth;
+        }
+      } else var lines = [text];
+
+      for (var i = 0; i < lines.length; i++) {
+        var oy = y + i * h * 0.6 | 0;
+        var lingrad = this.context.createLinearGradient(0, oy, 0, oy + h * 0.6 | 0);
+
+        for (var j = 0; j < gradient.length; j += 2) {
+          lingrad.addColorStop(gradient[j], gradient[j + 1]);
+        }
+
+        var text = lines[i];
+
+        this.fillStyle(lingrad).fillText(text, x, oy);
+      }
+
+      return this;
+    },
+
+    removeColor: function(color) {
+
+      color = cq.color(color);
+
+      var data = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
+      var pixels = data.data;
+
+      for (var x = 0; x < this.canvas.width; x++) {
+        for (var y = 0; y < this.canvas.height; y++) {
+          var i = (y * this.canvas.width + x) * 4;
+
+          if (pixels[i + 0] === color[0] && pixels[i + 1] === color[1] && pixels[i + 2] === color[2]) {
+            pixels[i + 3] = 0;
+          }
+
+
+        }
+      }
+
+      this.clear();
+      this.context.putImageData(data, 0, 0);
+
+      return this;
+    },
+
+    outline: function() {
+      var data = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
+      var pixels = data.data;
+
+      var newData = this.createImageData(this.canvas.width, this.canvas.height);
+      var newPixels = newData.data;
+
+      var canvas = this.canvas;
+
+      function check(x, y) {
+
+        if (x < 0) return 0;
+        if (x >= canvas.width) return 0;
+        if (y < 0) return 0;
+        if (y >= canvas.height) return 0;
+
+        var i = (x + y * canvas.width) * 4;
+
+        return pixels[i + 3] > 0;
+
+      }
+
+      for (var x = 0; x < this.canvas.width; x++) {
+        for (var y = 0; y < this.canvas.height; y++) {
+
+          var full = 0;
+          var i = (y * canvas.width + x) * 4;
+
+          if (!pixels[i + 3]) continue;
+
+          full += check(x - 1, y);
+          full += check(x + 1, y);
+          full += check(x, y - 1);
+          full += check(x, y + 1);
+
+          if (full !== 4) {
+
+            newPixels[i] = 255;
+            newPixels[i + 1] = 255;
+            newPixels[i + 2] = 255;
+            newPixels[i + 3] = 255;
+          }
+
+        }
+      }
+
+      this.context.putImageData(newData, 0, 0);
+
+      return this;
+    },
+
+    setHsl: function() {
+
+      if (arguments.length === 1) {
+        var args = arguments[0];
+      } else {
+        var args = arguments;
+      }
+
+      var data = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
+      var pixels = data.data;
+      var r, g, b, a, h, s, l, hsl = [],
+        newPixel = [];
+
+      for (var i = 0, len = pixels.length; i < len; i += 4) {
+        hsl = cq.rgbToHsl(pixels[i + 0], pixels[i + 1], pixels[i + 2]);
+
+        h = args[0] === false ? hsl[0] : cq.limitValue(args[0], 0, 1);
+        s = args[1] === false ? hsl[1] : cq.limitValue(args[1], 0, 1);
+        l = args[2] === false ? hsl[2] : cq.limitValue(args[2], 0, 1);
+
+        newPixel = cq.hslToRgb(h, s, l);
+
+        pixels[i + 0] = newPixel[0];
+        pixels[i + 1] = newPixel[1];
+        pixels[i + 2] = newPixel[2];
+      }
+
+      this.context.putImageData(data, 0, 0);
+
+      return this;
+    },
+
+    shiftHsl: function() {
+
+      if (arguments.length === 1) {
+        var args = arguments[0];
+      } else {
+        var args = arguments;
+      }
+
+      var data = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
+      var pixels = data.data;
+      var r, g, b, a, h, s, l, hsl = [],
+        newPixel = [];
+
+      for (var i = 0, len = pixels.length; i < len; i += 4) {
+        hsl = cq.rgbToHsl(pixels[i + 0], pixels[i + 1], pixels[i + 2]);
+
+        if (pixels[i + 0] !== pixels[i + 1] || pixels[i + 1] !== pixels[i + 2]) {
+          h = args[0] === false ? hsl[0] : cq.wrapValue(hsl[0] + args[0], 0, 1);
+          s = args[1] === false ? hsl[1] : cq.limitValue(hsl[1] + args[1], 0, 1);
+        } else {
+          h = hsl[0];
+          s = hsl[1];
+        }
+
+        l = args[2] === false ? hsl[2] : cq.limitValue(hsl[2] + args[2], 0, 1);
+
+        newPixel = cq.hslToRgb(h, s, l);
+
+        pixels[i + 0] = newPixel[0];
+        pixels[i + 1] = newPixel[1];
+        pixels[i + 2] = newPixel[2];
+      }
+
+
+      this.context.putImageData(data, 0, 0);
+
+      return this;
+    },
+
+    applyColor: function(color) {
+
+      if (COCOONJS) return this;
+      this.save();
+
+      this.globalCompositeOperation("source-in");
+      this.clear(color);
+
+      this.restore();
+
+      return this;
+    },
+
+    negative: function(src, dst) {
+
+      var data = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
+      var pixels = data.data;
+      var r, g, b, a, h, s, l, hsl = [],
+        newPixel = [];
+
+      for (var i = 0, len = pixels.length; i < len; i += 4) {
+        pixels[i + 0] = 255 - pixels[i + 0];
+        pixels[i + 1] = 255 - pixels[i + 1];
+        pixels[i + 2] = 255 - pixels[i + 2];
+      }
+
+      this.context.putImageData(data, 0, 0);
+
+      return this;
+    },
+
+    roundRect: function(x, y, width, height, radius) {
+
+      this.beginPath();
+      this.moveTo(x + radius, y);
+      this.lineTo(x + width - radius, y);
+      this.quadraticCurveTo(x + width, y, x + width, y + radius);
+      this.lineTo(x + width, y + height - radius);
+      this.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+      this.lineTo(x + radius, y + height);
+      this.quadraticCurveTo(x, y + height, x, y + height - radius);
+      this.lineTo(x, y + radius);
+      this.quadraticCurveTo(x, y, x + radius, y);
+      this.closePath();
+
+      return this;
+    },
+
+    markupText: function(text) {
+
+
+    },
+
+    wrappedText: function(text, x, y, maxWidth, lineHeight) {
+
+      var words = text.split(" ");
+
+      var lineHeight = lineHeight || this.fontHeight();
+
+      var ox = 0;
+      var oy = 0;
+
+      if (maxWidth) {
+        var line = 0;
+        var lines = [""];
+
+        for (var i = 0; i < words.length; i++) {
+          var word = words[i] + " ";
+          var wordWidth = this.context.measureText(word).width;
+
+          if (ox + wordWidth > maxWidth || words[i] === "\n") {
+            lines[++line] = "";
+            ox = 0;
+          }
+          if (words[i] !== "\n") {
+            lines[line] += word;
+
+            ox += wordWidth;
+          }
+
+
+        }
+      } else {
+        var lines = [text];
+      }
+
+      for (var i = 0; i < lines.length; i++) {
+        var oy = y + i * lineHeight | 0;
+
+        var text = lines[i];
+
+        this.fillText(text, x, oy);
+      }
+
+      return this;
+    },
+
+    fontHeights: {},
+
+    fontHeight: function() {
+      var font = this.font();
+
+      if (!this.fontHeights[font]) {
+        var temp = cq(100, 100);
+        var height = 0;
+        var changes = {};
+        temp.font(font).fillStyle("#fff");
+        temp.textBaseline("bottom").fillText("gM", 25, 100);
+        temp.trim(false, changes);
+        height += changes.bottom;
+
+        var temp = cq(100, 100);
+        var changes = {};
+        temp.font(font).fillStyle("#fff");
+        temp.textBaseline("top").fillText("gM", 25, 0);
+        temp.trim(false, changes);
+        height += changes.top;
+
+        var temp = cq(100, 100);
+        var changes = {};
+        temp.font(font).fillStyle("#fff");
+        temp.textBaseline("alphabetic").fillText("gM", 50, 50);
+        temp.trim(false, changes);
+        height += temp.height;
+
+        this.fontHeights[font] = height;
+      }
+
+      return this.fontHeights[font];
+    },
+
+    textBoundaries: function(text, maxWidth) {
+      var words = text.split(" ");
+
+      var h = this.fontHeight();
+
+      var ox = 0;
+      var oy = 0;
+
+      if (maxWidth) {
+        var line = 0;
+        var lines = [""];
+
+        for (var i = 0; i < words.length; i++) {
+          var word = words[i] + " ";
+          var wordWidth = this.context.measureText(word).width;
+
+          if (ox + wordWidth > maxWidth || words[i] === "\n") {
+            lines[++line] = "";
+            ox = 0;
+          }
+
+          if (words[i] !== "\n") {
+            lines[line] += word;
+            ox += wordWidth;
+          }
+        }
+      } else {
+        var lines = [text];
+        maxWidth = this.measureText(text).width;
+      }
+
+      return {
+        height: lines.length * h,
+        width: maxWidth,
+        lines: lines.length,
+        lineHeight: h
+      }
+    },
+
+    repeatImageRegion: function(image, sx, sy, sw, sh, dx, dy, dw, dh) {
+      this.save();
+      this.rect(dx, dy, dw, dh);
+      this.clip();
+
+      for (var x = 0, len = Math.ceil(dw / sw); x < len; x++) {
+        for (var y = 0, leny = Math.ceil(dh / sh); y < leny; y++) {
+          this.drawImage(image, sx, sy, sw, sh, dx + x * sw, dy + y * sh, sw, sh);
+        }
+      }
+
+      this.restore();
+
+      return this;
+    },
+
+    repeatImage: function(image, x, y, w, h) {
+      // if (!env.details) return this;
+
+      if (arguments.length < 9) {
+
+        this.repeatImageRegion(image, 0, 0, image.width, image.height, x, y, w, h);
+
+      } else {
+
+        this.repeatImageRegion.apply(this, arguments);
+
+      }
+
+      return this;
+    },
+
+    borderImageEmptyRegion: [0, 0, 0, 0],
+
+    borderImage: function(image, x, y, w, h, t, r, b, l, fill) {
+
+      // if (!env.details) return this;
+
+      if (typeof t === "object") {
+
+        var region = t.region;
+
+        if (!region) {
+
+          region = this.borderImageEmptyRegion;
+          region[2] = image.width;
+          region[3] = image.height;
+
+        }
+
+        if (t.padding) {
+
+          var padding = t.padding;
+
+          this.drawImage(image, 
+            region[0] + padding, 
+            region[1] + padding, 
+            (region[2] - padding * 2), 
+            (region[3] - padding * 2), 
+            x + padding, y + padding, 
+            w - padding * 2, 
+            h - padding * 2
+          );
+
+
+          this.drawImage(image, region[0], region[1] + padding, padding, region[3] - 2 * padding, x, y + padding, padding, h - padding * 2);
+          this.drawImage(image, region[0] + region[2] - padding, region[1] + padding, padding, region[3] - 2 * padding, x + w - padding, y + padding, padding, h - padding * 2);
+          this.drawImage(image, region[0] + padding, region[1], region[2] - padding * 2, padding, x + padding, y, w - padding * 2, padding);
+          this.drawImage(image, region[0] + padding, region[1] + region[3] - padding, region[2] - padding * 2, padding, x + padding, y + h - padding, w - padding * 2, padding);
+
+          this.drawImage(image, region[0], region[1], padding, padding, x, y, padding, padding);
+          this.drawImage(image, region[0], region[1] + region[3] - padding, padding, padding, x, y + h - padding, padding, padding);
+          this.drawImage(image, region[0] + region[2] - padding, region[1], padding, padding, x + w - padding, y, padding, padding);
+          this.drawImage(image, region[0] + region[2] - padding, region[1] + region[3] - padding, padding, padding, x + w - padding, y + h - padding, padding, padding);
+
+
+
+        }
+
+        /* complex */
+        else {
+
+          var bottomLeft = t.bottomLeft || [0, 0, 0, 0];
+          var bottomRight = t.bottomRight || [0, 0, 0, 0];
+          var topLeft = t.topLeft || [0, 0, 0, 0];
+          var topRight = t.topRight || [0, 0, 0, 0];
+
+          var clh = bottomLeft[3] + topLeft[3];
+          var crh = bottomRight[3] + topRight[3];
+          var ctw = topLeft[2] + topRight[2];
+          var cbw = bottomLeft[2] + bottomRight[2];
+
+          t.fillPadding = [0, 0, 0, 0];
+
+          if (t.left) t.fillPadding[0] = t.left[2];
+          if (t.top) t.fillPadding[1] = t.top[3];
+          if (t.right) t.fillPadding[2] = t.right[2];
+          if (t.bottom) t.fillPadding[3] = t.bottom[3];
+
+          // if (!t.fillPadding) t.fillPadding = [0, 0, 0, 0];
+
+          if (t.fill) {
+            this.drawImage(image, t.fill[0], t.fill[1], t.fill[2], t.fill[3], x + t.fillPadding[0], y + t.fillPadding[1], w - t.fillPadding[2] - t.fillPadding[0], h - t.fillPadding[3] - t.fillPadding[1]);
+          } else {
+            // this.fillRect(x + t.fillPadding[0], y + t.fillPadding[1], w - t.fillPadding[2] - t.fillPadding[0], h - t.fillPadding[3] - t.fillPadding[1]);
+          }
+
+          /* sides */
+
+          if (t.left) this[t.left[4] === "stretch" ? "drawImage" : "repeatImage"](image, t.left[0], t.left[1], t.left[2], t.left[3], x, y + topLeft[3], t.left[2], h - clh);
+          if (t.right) this[t.right[4] === "stretch" ? "drawImage" : "repeatImage"](image, t.right[0], t.right[1], t.right[2], t.right[3], x + w - t.right[2], y + topRight[3], t.right[2], h - crh);
+          if (t.top) this[t.top[4] === "stretch" ? "drawImage" : "repeatImage"](image, t.top[0], t.top[1], t.top[2], t.top[3], x + topLeft[2], y, w - ctw, t.top[3]);
+          if (t.bottom) this[t.bottom[4] === "stretch" ? "drawImage" : "repeatImage"](image, t.bottom[0], t.bottom[1], t.bottom[2], t.bottom[3], x + bottomLeft[2], y + h - t.bottom[3], w - cbw, t.bottom[3]);
+
+          /* corners */
+
+          if (t.bottomLeft) this.drawImage(image, t.bottomLeft[0], t.bottomLeft[1], t.bottomLeft[2], t.bottomLeft[3], x, y + h - t.bottomLeft[3], t.bottomLeft[2], t.bottomLeft[3]);
+          if (t.topLeft) this.drawImage(image, t.topLeft[0], t.topLeft[1], t.topLeft[2], t.topLeft[3], x, y, t.topLeft[2], t.topLeft[3]);
+          if (t.topRight) this.drawImage(image, t.topRight[0], t.topRight[1], t.topRight[2], t.topRight[3], x + w - t.topRight[2], y, t.topRight[2], t.topRight[3]);
+          if (t.bottomRight) this.drawImage(image, t.bottomRight[0], t.bottomRight[1], t.bottomRight[2], t.bottomRight[3], x + w - t.bottomRight[2], y + h - t.bottomRight[3], t.bottomRight[2], t.bottomRight[3]);
+
+        }
+
+      } else {
+
+
+        /* top */
+        if (t > 0 && w - l - r > 0) this.drawImage(image, l, 0, image.width - l - r, t, x + l, y, w - l - r, t);
+
+        /* bottom */
+        if (b > 0 && w - l - r > 0) this.drawImage(image, l, image.height - b, image.width - l - r, b, x + l, y + h - b, w - l - r, b);
+        //      console.log(x, y, w, h, t, r, b, l);
+        //      console.log(image, 0, t, l, image.height - b - t, x, y + t, l, h - b - t);
+        /* left */
+        if (l > 0 && h - b - t > 0) this.drawImage(image, 0, t, l, image.height - b - t, x, y + t, l, h - b - t);
+
+
+        /* right */
+        if (r > 0 && h - b - t > 0) this.drawImage(image, image.width - r, t, r, image.height - b - t, x + w - r, y + t, r, h - b - t);
+
+        /* top-left */
+        if (l > 0 && t > 0) this.drawImage(image, 0, 0, l, t, x, y, l, t);
+
+        /* top-right */
+        if (r > 0 && t > 0) this.drawImage(image, image.width - r, 0, r, t, x + w - r, y, r, t);
+
+        /* bottom-right */
+        if (r > 0 && b > 0) this.drawImage(image, image.width - r, image.height - b, r, b, x + w - r, y + h - b, r, b);
+
+        /* bottom-left */
+        if (l > 0 && b > 0) this.drawImage(image, 0, image.height - b, l, b, x, y + h - b, l, b);
+
+        if (fill) {
+          if (typeof fill === "string") {
+            this.fillStyle(fill).fillRect(x + l, y + t, w - l - r, h - t - b);
+          } else {
+            if (w - l - r > 0 && h - t - b > 0)
+              this.drawImage(image, l, t, image.width - r - l, image.height - b - t, x + l, y + t, w - l - r, h - t - b);
+          }
+        }
+      }
+    },
+
+    setPixel: function(color, x, y) {
+
+      /* fillRect is slow! */
+
+      return this.fillStyle(color).fillRect(x, y, 1, 1);
+
+      /* this is how it should work - but it does not */
+
+      color = cq.color(color);
+
+      var pixel = this.createImageData(1, 1);
+
+      pixel.data[0] = color[0];
+      pixel.data[1] = color[1];
+      pixel.data[2] = color[2];
+      pixel.data[3] = 255;
+
+      this.putImageData(pixel, x, y);
+
+      return this;
+    },
+
+    getPixel: function(x, y) {
+
+      var pixel = this.context.getImageData(x, y, 1, 1).data;
+
+      return cq.color([pixel[0], pixel[1], pixel[2], pixel[3]]);
+
+    },
+
+    clearRect: function(x, y, w, h) {
+
+      this.context.clearRect(x, y, w, h);
+
+      return this;
+
+    },
+
+    stroke: function() {
+
+      this.context.stroke();
+
+      return this;
+
+    },
+
+    createImageData: function(width, height) {
+
+      if (false && this.context.createImageData) {
+
+        return this.context.createImageData.apply(this.context, arguments);
+
+      } else {
+
+        if (!this.emptyCanvas) {
+
+          this.emptyCanvas = cq.createCanvas(width, height);
+          this.emptyCanvasContext = this.emptyCanvas.getContext("2d");
+
+        }
+
+        this.emptyCanvas.width = width;
+        this.emptyCanvas.height = height;
+
+        return this.emptyCanvasContext.getImageData(0, 0, width, height);
+      }
+
+    },
+
+    strokeLine: function(x1, y1, x2, y2) {
+
+      this.beginPath();
+
+      if (typeof x2 === "undefined") {
+        this.moveTo(x1.x, x1.y);
+        this.lineTo(y1.x, y1.y);
+      } else {
+        this.moveTo(x1, y1);
+        this.lineTo(x2, y2);
+      }
+
+      this.stroke();
+
+      return this;
+
+    },
+
+    shadowOffset: function(x, y) {
+
+      this.context.shadowOffsetX = x;
+      this.context.shadowOffsetY = y;
+
+      return this;
+
+    },
+
+    setLineDash: function(dash) {
+
+      if (this.context.setLineDash) {
+        this.context.setLineDash(dash);
+        return this;
+      } else return this;
+
+    },
+
+    measureText: function(text) {
+
+      return this.context.measureText(text);
+
+    },
+
+    getLineDash: function() {
+
+      return this.context.getLineDash();
+
+    },
+
+    createRadialGradient: function(x0, y0, r0, x1, y1, r1) {
+
+      return this.context.createRadialGradient(x0, y0, r0, x1, y1, r1);
+
+    },
+
+    createLinearGradient: function(x0, y0, x1, y1) {
+
+      return this.context.createLinearGradient(x0, y0, x1, y1);
+
+    },
+
+    createPattern: function(image, repeat) {
+
+      return this.context.createPattern(image, repeat);
+
+    },
+
+    getImageData: function(sx, sy, sw, sh) {
+
+      return this.context.getImageData(sx, sy, sw, sh);
+
+    },
+
+    /* If you think that I am retarded because I use fillRect to set 
+       pixels - read about premultipled alpha in canvas */
+
+    writeMeta: function(data) {
+
+      var json = JSON.stringify(data);
+
+      json = encodeURIComponent(json);
+
+      var bytes = [];
+
+      for (var i = 0; i < json.length; i++) {
+        bytes.push(json.charCodeAt(i));
+        //      console.log(json[i])
+      }
+
+      bytes.push(127);
+
+      var x = this.width - 1;
+      var y = this.height - 1;
+
+      var pixel = [];
+
+      while (bytes.length) {
+
+        var byte = bytes.shift();
+
+        pixel.unshift(byte * 2);
+        //        console.log(x + String.fromCharCode(byte), byte);
+
+        if (!bytes.length)
+          for (var i = 0; i < 3 - pixel.length; i++) pixel.unshift(254);
+
+        if (pixel.length === 3) {
+          this.fillStyle(cq.color(pixel).toRgb()).fillRect(x, y, 1, 1);
+          pixel = [];
+          x--;
+
+          if (x < 0) {
+            y--;
+            x = this.width - 1;
+          }
+        }
+      }
+
+      return this;
+
+    },
+
+    /* setters / getters */
+
+    strokeStyle: function(style) {
+
+      if (style == null) {
+
+        return this.context.strokeStyle;
+
+      } else {
+
+        this.context.strokeStyle = style;
+
+        return this;
+
+      }
+
+    },
+
+    fillStyle: function(style) {
+
+      if (style == null) {
+
+        return this.context.fillStyle;
+
+      } else {
+
+        this.context.fillStyle = style;
+
+        return this;
+
+      }
+
+    },
+
+    font: function(font) {
+
+      if (font == null) {
+
+        return this.context.font;
+
+      } else {
+
+        this.context.font = font;
+
+        return this;
+      }
+
+    },
+
+    readMeta: function() {
+
+      var bytes = [];
+
+      var x = this.width - 1;
+      var y = this.height - 1;
+
+      while (true) {
+        var pixel = this.getPixel(x, y);
+
+        var stop = false;
+
+        for (var i = 0; i < 3; i++) {
+
+          if (pixel[2 - i] === 254) stop = true;
+
+          else bytes.push(pixel[2 - i] / 2 | 0);
+
+        }
+
+        if (stop) break;
+
+        x--;
+
+        if (x < 0) {
+          y--;
+          x = this.width - 1;
+          break;
+        }
+      }
+
+
+      var json = "";
+
+      while (bytes.length) {
+        json += String.fromCharCode(bytes.shift());
+      }
+
+      var data = false;
+
+      console.log(json);
+
+      try {
+        data = JSON.parse(decodeURIComponent(json));
+      } catch (e) {
+
+      }
+
+      return data;
+
+    },
+
+    get width() {
+      return this.canvas.width;
+    },
+
+    get height() {
+      return this.canvas.height;
+    },
+
+    set width(w) {
+      this.canvas.width = w;
+      this.update();
+      return this.canvas.width;
+    },
+
+    set height(h) {
+      this.canvas.height = h;
+      this.update();
+      return this.canvas.height;
+    }
+
+
+  };
+
+  /* extend Layer with drawing context methods */
+
+  var methods = ["arc", "arcTo", "beginPath", "bezierCurveTo", "clip", "closePath", "createLinearGradient", "createRadialGradient", "createPattern", "drawFocusRing", "drawImage", "fill", "fillRect", "fillText", "getImageData", "isPointInPath", "lineTo", "measureText", "moveTo", "putImageData", "quadraticCurveTo", "rect", "restore", "rotate", "scale", "setTransform", "strokeRect", "strokeText", "transform", "translate", "setLineDash"];
+
+  for (var i = 0; i < methods.length; i++) {
+
+    var name = methods[i];
+
+    if (cq.Layer.prototype[name]) continue;
+
+    cq.Layer.prototype[name] = (function(method) {
+
+      return function() {
+
+        var args = new Array(arguments.length);
+
+        for (var i = 0; i < args.length; ++i) {
+
+          args[i] = arguments[i];
+
+        }
+
+        cq.fastApply(method, this.context, args);
+
+        return this;
+      }
+
+    })(CanvasRenderingContext2D.prototype[name]);
+
+
+    continue;
+
+
+    if (!this.debug) {
+      // if (!cq.Layer.prototype[name]) cq.Layer.prototype[name] = Function("this.context." + name + ".apply(this.context, arguments); return this;");
+
+      var self = this;
+
+      (function(name) {
+
+        cq.Layer.prototype[name] = function() {
+          // this.context[name].apply(this.context, arguments);
+
+          cq.fastApply(this.context[name], this.context, arguments);
+
+          return this;
+        }
+
+      })(name);
+
+    } else {
+
+      var self = this;
+
+      (function(name) {
+
+        cq.Layer.prototype[name] = function() {
+          try {
+            this.context[name].apply(this.context, arguments);
+            return this;
+          } catch (e) {
+            var err = new Error();
+            console.log(err.stack);
+            throw (e + err.stack);
+
+            console.log(e, name, arguments);
+          }
+        }
+
+      })(name);
+
+    }
+
+  };
+
+  /* create setters and getters */
+
+  var properties = ["globalAlpha", "globalCompositeOperation", "lineCap", "lineJoin", "lineWidth", "miterLimit", "shadowOffsetX", "shadowOffsetY", "shadowBlur", "shadowColor", "textAlign", "textBaseline", "lineDashOffset"];
+
+  for (var i = 0; i < properties.length; i++) {
+
+    var name = properties[i];
+
+    if (!cq.Layer.prototype[name]) cq.Layer.prototype[name] = Function("if(arguments.length) { this.context." + name + " = arguments[0]; return this; } else { return this.context." + name + "; }");
+
+  };
+
+  /* color */
+
+  cq.Color = function(data, type) {
+
+    if (arguments.length) this.parse(data, type);
+  }
+
+  cq.Color.prototype = {
+
+    toString: function() {
+      return this.toRgb();
+    },
+
+    parse: function(args, type) {
+      if (args[0] instanceof cq.Color) {
+        this[0] = args[0][0];
+        this[1] = args[0][1];
+        this[2] = args[0][2];
+        this[3] = args[0][3];
+        return;
+      }
+
+      if (typeof args === "string") {
+        var match = null;
+
+        if (args[0] === "#") {
+          var rgb = cq.hexToRgb(args);
+          this[0] = rgb[0];
+          this[1] = rgb[1];
+          this[2] = rgb[2];
+          this[3] = 1.0;
+        } else if (match = args.match(/rgb\((.*),(.*),(.*)\)/)) {
+          this[0] = match[1] | 0;
+          this[1] = match[2] | 0;
+          this[2] = match[3] | 0;
+          this[3] = 1.0;
+        } else if (match = args.match(/rgba\((.*),(.*),(.*)\)/)) {
+          this[0] = match[1] | 0;
+          this[1] = match[2] | 0;
+          this[2] = match[3] | 0;
+          this[3] = match[4] | 0;
+        } else if (match = args.match(/hsl\((.*),(.*),(.*)\)/)) {
+          this.fromHsl(match[1], match[2], match[3]);
+        } else if (match = args.match(/hsv\((.*),(.*),(.*)\)/)) {
+          this.fromHsv(match[1], match[2], match[3]);
+        }
+      } else {
+        switch (type) {
+          case "hsl":
+          case "hsla":
+
+            this.fromHsl(args[0], args[1], args[2], args[3]);
+            break;
+
+          case "hsv":
+          case "hsva":
+
+            this.fromHsv(args[0], args[1], args[2], args[3]);
+            break;
+
+          default:
+            this[0] = args[0];
+            this[1] = args[1];
+            this[2] = args[2];
+            this[3] = typeof args[3] === "undefined" ? 1.0 : args[3];
+            break;
+        }
+      }
+    },
+
+    a: function(a) {
+      return this.alpha(a);
+    },
+
+    alpha: function(a) {
+      this[3] = a;
+      return this;
+    },
+
+    fromHsl: function() {
+      var components = arguments[0] instanceof Array ? arguments[0] : arguments;
+
+      var color = cq.hslToRgb(parseFloat(components[0]), parseFloat(components[1]), parseFloat(components[2]));
+
+      this[0] = color[0];
+      this[1] = color[1];
+      this[2] = color[2];
+      this[3] = typeof arguments[3] === "undefined" ? 1.0 : arguments[3];
+    },
+
+    fromHsv: function() {
+      var components = arguments[0] instanceof Array ? arguments[0] : arguments;
+      var color = cq.hsvToRgb(parseFloat(components[0]), parseFloat(components[1]), parseFloat(components[2]));
+
+      this[0] = color[0];
+      this[1] = color[1];
+      this[2] = color[2];
+      this[3] = typeof arguments[3] === "undefined" ? 1.0 : arguments[3];
+    },
+
+    toArray: function() {
+      return [this[0], this[1], this[2], this[3]];
+    },
+
+    toRgb: function() {
+      return "rgb(" + this[0] + ", " + this[1] + ", " + this[2] + ")";
+    },
+
+    toRgba: function() {
+      return "rgba(" + this[0] + ", " + this[1] + ", " + this[2] + ", " + this[3] + ")";
+    },
+
+    toHex: function() {
+      return cq.rgbToHex(this[0], this[1], this[2]);
+    },
+
+    toHsl: function() {
+      var c = cq.rgbToHsl(this[0], this[1], this[2]);
+      c[3] = this[3];
+      return c;
+    },
+
+    toHsv: function() {
+      var c = cq.rgbToHsv(this[0], this[1], this[2]);
+      c[3] = this[3];
+      return c;
+    },
+
+    gradient: function(target, steps) {
+      var targetColor = cq.color(target);
+    },
+
+    shiftHsl: function() {
+      var hsl = this.toHsl();
+
+      if (this[0] !== this[1] || this[1] !== this[2]) {
+        var h = arguments[0] === false ? hsl[0] : cq.wrapValue(hsl[0] + arguments[0], 0, 1);
+        var s = arguments[1] === false ? hsl[1] : cq.limitValue(hsl[1] + arguments[1], 0, 1);
+      } else {
+        var h = hsl[0];
+        var s = hsl[1];
+      }
+
+      var l = arguments[2] === false ? hsl[2] : cq.limitValue(hsl[2] + arguments[2], 0, 1);
+
+      this.fromHsl(h, s, l);
+
+      return this;
+    },
+
+    setHsl: function() {
+      var hsl = this.toHsl();
+
+      var h = arguments[0] === false ? hsl[0] : cq.limitValue(arguments[0], 0, 1);
+      var s = arguments[1] === false ? hsl[1] : cq.limitValue(arguments[1], 0, 1);
+      var l = arguments[2] === false ? hsl[2] : cq.limitValue(arguments[2], 0, 1);
+
+      this.fromHsl(h, s, l);
+
+      return this;
+    },
+
+    mix: function(color, amount) {
+      color = cq.color(color);
+
+      for (var i = 0; i < 4; i++)
+        this[i] = cq.mix(this[i], color[i], amount);
+
+      return this;
+    }
+
+  };
+
+  window["cq"] = window["CanvasQuery"] = cq;
+
+
+  return cq;
+
+})();
+
+/* file: src/layer/Layer.js */
+
+PLAYGROUND.Renderer = function(app) {
+
+  this.app = app;
+
+  app.on("create", this.create.bind(this));
+  app.on("resize", this.resize.bind(this));
+
+};
+
+PLAYGROUND.Renderer.plugin = true;
+
+PLAYGROUND.Renderer.prototype = {
+
+  create: function(data) {
+
+    this.app.layer = cq().appendTo(this.app.container);
+
+    if (!this.app.customContainer) {
+      this.app.container.style.margin = "0px";
+      this.app.container.style.overflow = "hidden";
+    }
+
+  },
+
+  resize: function(data) {
+
+    var app = this.app;
+
+    var layer = app.layer;
+
+    layer.width = app.width;
+    layer.height = app.height;
+
+    layer.canvas.style.transformOrigin = "0 0";
+    layer.canvas.style.transform = "translate(" + app.offsetX + "px," + app.offsetY + "px) scale(" + app.scale + ", " + app.scale + ")";
+    layer.canvas.style.transformStyle = "preserve-3d";
+
+    layer.canvas.style.webkitTransformOrigin = "0 0";
+    layer.canvas.style.webkitTransform = "translate(" + app.offsetX + "px," + app.offsetY + "px) scale(" + app.scale + ", " + app.scale + ")";
+    layer.canvas.style.webkitTransformStyle = "preserve-3d";
+
+    cq.smoothing = this.app.smoothing;
+    layer.update();
+
+    layer.canvas.style.imageRendering = this.app.smoothing ? "auto" : "pixelated";
+  }
+
+};
+
+/* file: src/layer/Transitions.js */
+
+PLAYGROUND.Transitions = function(app) {
+
+  this.app = app;
+
+  app.on("enterstate", this.enterstate.bind(this));
+  app.on("postrender", this.postrender.bind(this));
+  app.on("step", this.step.bind(this));
+
+  this.progress = 1;
+  this.lifetime = 0;
+};
+
+PLAYGROUND.Transitions.plugin = true;
+
+PLAYGROUND.Transitions.prototype = {
+
+  enterstate: function(data) {
+
+    this.screenshot = this.app.layer.cache();
+
+    if (data.prev) {
+      this.lifetime = 0;
+      this.progress = 0;
+    }
+
+  },
+
+  postrender: function() {
+
+    if (this.progress >= 1) return;
+
+    PLAYGROUND.Transitions.Split(this, this.progress);
+
+  },
+
+  step: function(delta) {
+
+    if (this.progress >= 1) return;
+
+    this.lifetime += delta;
+
+    this.progress = Math.min(this.lifetime / 0.5, 1);
+
+  }
+
+};
+
+PLAYGROUND.Transitions.Implode = function(manager, progress) {
+
+  var app = manager.app;
+  var layer = app.layer;
+
+  progress = app.ease(progress, "outCubic");
+
+  var negative = 1 - progress;
+
+  layer.save();
+  layer.tars(app.center.x, app.center.y, 0.5, 0.5, 0, 0.5 + 0.5 * negative, negative);
+  layer.drawImage(manager.screenshot, 0, 0);
+
+  layer.restore();
+
+};
+
+PLAYGROUND.Transitions.Split = function(manager, progress) {
+
+  var app = manager.app;
+  var layer = app.layer;
+
+  progress = app.ease(progress, "inOutCubic");
+
+  var negative = 1 - progress;
+
+  layer.save();
+
+  layer.a(negative).clear("#fff").ra();
+
+  layer.drawImage(manager.screenshot, 0, 0, app.width, app.height / 2 | 0, 0, 0, app.width, negative * app.height / 2 | 0);
+  layer.drawImage(manager.screenshot, 0, app.height / 2 | 0, app.width, app.height / 2 | 0, 0, app.height / 2 + progress * app.height / 2 + 1 | 0, app.width, Math.max(1, negative * app.height * 0.5 | 0));
+
+  layer.restore();
+
+};
+
+/* file: src/layer/LoadingScreen.js */
+
+PLAYGROUND.LoadingScreen = {
+
+  logoRaw: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANoAAAASBAMAAADPiN0xAAAAGFBMVEUAAQAtLixHSUdnaGaJioimqKXMzsv7/fr5shgVAAAAAWJLR0QAiAUdSAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB98EAwkeA4oQWJ4AAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAB9klEQVQ4y72UvW+rMBDAz+FrpVKrrFmesmapWNOlrKjSe1kZ+uoVAvj+/frujG1SaJcqJwU7voOf7xMQzQmsIDi5NPTMsLRntH3U+F6SAZo3NlCvcgBFJz8o+vkDiE63lI95Y/UmpinsZWkgJWJiDbAVQ16htptxSTNloIlugwaw001Ey3ASF3so6L1qLNXzQS5S0UGKL/CI5wWNriE0UH9Yty37LqIVg+wsqu7Ix0MwVBSF/dU+jv2SNnma021LEdPqVnMeU3xAu0kXcSGjmq7Ox4E2Wn88LZ2+EFj3avjixzai6VPVyuYveZLHF2XfdDnvAq27DIHGuq+0DJFsE30OtB1KqOwd8Dr7PcM4b+jfj2g5lp4WyntBK66qua3JzEA+uXJpwH/NlVuzRVPY/kTLB2mjuN+KwdZ8FOy8j2gDbEUSqumnSCY4lf4ibq3IhVM4ycZQRnv+zFqVdJQVn6BxvUqebGpuaNo3sZxwBzjajiMZOoBiwyVF+kCr+nUaJOaGpnAeRPPJZTr4FqmHRXcneEo4DqQ/ftfdnLeDrUAME8xWKPeKCwW6YkEpXfs3p1EWJhdcUAYP0TI/uYaV8cgjwBovaeyWwji2T9rTFIdS/cP/MnkTLRUWxgNNZVin7bT5fqT9miDcUVJzR1gRpfIONMmulU+5Qqr6zXAUqAAAAABJRU5ErkJggg==",
+
+  create: function() {
+
+    var self = this;
+
+    this.logo = new Image;
+
+    this.logo.addEventListener("load", function() {
+      self.ready = true;
+    });
+
+    this.logo.src = this.logoRaw;
+
+    this.background = "#272822";
+    this.app.container.style.background = "#272822";
+
+    if (window.getComputedStyle) {
+      // this.background = window.getComputedStyle(document.body).backgroundColor || "#000";
+    }
+
+
+  },
+
+  enter: function() {
+
+    this.current = 0;
+
+  },
+
+  leave: function() {
+
+    this.locked = true;
+
+    this.animation = this.app.tween(this)
+      .to({
+        current: 1
+      }, 0.5);
+
+  },
+
+  step: function(delta) {
+
+    if (this.locked) {
+      if (this.animation.finished) this.locked = false;
+    } else {
+      this.current = this.current + Math.abs(this.app.loader.progress - this.current) * delta;
+    }
+
+  },
+
+  ready: function() {
+
+
+  },
+
+  render: function() {
+
+    if (!this.ready) return;
+
+    this.app.layer.clear(this.background);
+
+    this.app.layer.fillStyle("#fff");
+
+    this.app.layer.save();
+    this.app.layer.align(0.5, 0.5);
+    this.app.layer.globalCompositeOperation("lighter");
+    this.app.layer.drawImage(this.logo, this.app.center.x, this.app.center.y);
+
+    var w = this.current * this.logo.width;
+
+    this.app.layer.fillStyle("#fff");
+
+    this.app.layer.fillRect(this.app.center.x, this.app.center.y + 32, w, 12);
+    this.app.layer.fillRect(this.app.center.x, this.app.center.y + 32, this.logo.width, 4);
+
+    this.app.layer.restore();
+
+
+
+  }
+
+};
+module.exports = playground;playground.Application = PLAYGROUND.Application;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "playground.js",
+  "version": "0.0.3",
+  "description": "Essential framework for javascript gamedevelopers.",
+  "homepage": "http://playgroundjs.com/",
+  "author": {
+    "name": "Przemysław Sikorski",
+    "email": "rezoner1337@gmail.com",
+    "url": "http://rezoner.net"
+  },
+  "scripts": {
+    "dist": "node build"
+  },
+  "main": "./build/commonjs/playground.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/rezoner/playground.git"
+  },
+  "devDependencies": {
+    "shelljs": "^0.5.1"
+  },
+  "license": "MIT"
+}

--- a/plugins/playground.three.js
+++ b/plugins/playground.three.js
@@ -1,77 +1,91 @@
 /*
-
   A bunch of helpers for Three.js
-
   It is still work in progress
-
 */
 
 (function() {
 
-  /* texture loader */
+  if (require) {
+    THREE = require('three');
+  }
 
-  PLAYGROUND.Application.prototype.loadTexture = function(path) {
 
-    if (!this.textures) this.textures = {};
+  var mixin = {
 
-    var resourceName = "texture " + path;
+    /* texture loader */
 
-    var app = this;
+    loadTexture: function(path) {
 
-    var assetPath = this.getAssetEntry(path, "textures", "png");
+      if (!this.textures) this.textures = {};
 
-    if (this.textures[assetPath.key]) return;
+      var resourceName = "texture " + path;
 
-    this.loader.add(resourceName);
+      var app = this;
 
-    var loader = new THREE.TextureLoader();
+      var assetPath = this.getAssetEntry(path, "textures", "png");
 
-    loader.load(
+      if (this.textures[assetPath.key]) return;
 
-      assetPath.url,
+      this.loader.add(resourceName);
 
-      function(texture) {
+      var loader = new THREE.TextureLoader();
 
-        app.textures[assetPath.key] = texture;
+      loader.load(
 
-        app.loader.success(resourceName);
+        assetPath.url,
 
-      }
-    );
+        function(texture) {
 
+          app.textures[assetPath.key] = texture;
+
+          app.loader.success(resourceName);
+
+        }
+      );
+
+    },
+
+    /* object loader */
+
+    loadObject: function(path) {
+
+      var app = this;
+
+      if (!this.objects) this.objects = {};
+
+      var loaderID = "object " + path;
+
+      var assetPath = this.getAssetEntry(path, "objects", "json");
+
+      if (this.objects[assetPath.key]) return;
+
+      this.loader.add(loaderID);
+
+      var loader = new THREE.ObjectLoader();
+
+      loader.load(
+
+        assetPath.url,
+
+        function(object) {
+
+          app.objects[assetPath.key] = object;
+
+          app.loader.success(loaderID);
+
+        }
+      );
+
+    }
   };
 
-  /* object loader */
+  if (typeof module === 'object') {
+    module.exports = mixin;
+  }
 
-  PLAYGROUND.Application.prototype.loadObject = function(path) {
-
-    var app = this;
-
-    if (!this.objects) this.objects = {};
-
-    var loaderID = "object " + path;
-
-    var assetPath = this.getAssetEntry(path, "objects", "json");
-
-    if (this.objects[assetPath.key]) return;
-
-    this.loader.add(loaderID);
-
-    var loader = new THREE.ObjectLoader();
-
-    loader.load(
-
-      assetPath.url,
-
-      function(object) {
-
-        app.objects[assetPath.key] = object;
-
-        app.loader.success(loaderID);
-
-      }
-    );
-
-  };
+  if (typeof PLAYGROUND !== 'undefined') {
+    PLAYGROUND.Application.prototype.loadTexture = mixin.loadTexture;
+    PLAYGROUND.Application.prototype.loadObject = mixin.loadObject;
+  }
 
 })();


### PR DESCRIPTION
If this pull request is merged, some users (such as myself) will now be able to load playground.js by simply using `require` (the CommonJS-style of importing modules), depending on their set-up:

``` javascript
var playground = require('playground');
```

Much easier for people like me, and it will definitely make it easier for developers to organize their code. Again, no need of script tags.

This pull request adds a `package.json` file for the sake of compatibility with npm, a `.gitignore` file to ignore the `node_modules` folder, enhances `plugins/playground.three.js` to be loadable via `require` and enhances build.js to distribute a CommonJS-equivalent of the build files.

---

Now, what about plugins?

The answer to that is to turn plugins into mixins, but only on CommonJS environments, so that those who are not using CommonJS, they won't be affected. As a preview of how things would work out, I converted `playground.three.js` so that you can see it for ourself. And, in order to use the mixin, one can manually extend the `Application` class with the plugin, like so:

``` javascript
var Application = require('playground.js').Application;
var playgroundThreeMixin = require('playground.js/plugins/playground.three.js').playgroundThreeMixin;

Object.assign(Application.prototype, playgroundThreeMixin);

// Application should now be extended.
```

---

**[Demo](http://shovon.github.io/playground-commonjs-test/)** | **[Source](https://github.com/shovon/playground-commonjs-test)**
