### PR TITLE
added missing .fill() method; fixed .polygon() method, supporting def…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bower_components
 Thumbs.db
 *.sublime-*
 *.idea
+.DS_Store

--- a/build/commonjs/playground.js
+++ b/build/commonjs/playground.js
@@ -4075,19 +4075,19 @@ PLAYGROUND.LoadingScreen = {
 
 /* file: src/lib/CanvasQuery.js */
 
-/*     
+/*
 
   Canvas Query r6
-  
+
   http://canvasquery.com
-  
+
   (c) 2012-2015 http://rezoner.net
-  
+
   Canvas Query may be freely distributed under the MIT license.
 
   r5
 
-  ! fixed: leaking arguments in fastApply bailing out optimization 
+  ! fixed: leaking arguments in fastApply bailing out optimization
   + cacheText
   + compare
   + checkerboard
@@ -4535,10 +4535,10 @@ PLAYGROUND.LoadingScreen = {
       if (arguments[0] instanceof Image || arguments[0] instanceof Canvas || arguments[0] instanceof ImageBitmap) {
 
         var image = arguments[0];
-        
+
         result.width = image.width;
         result.height = image.height;
-        
+
         result.getContext("2d").drawImage(image, 0, 0);
 
       } else {
@@ -5171,6 +5171,8 @@ PLAYGROUND.LoadingScreen = {
 
 
     polygon: function(array, x, y) {
+      if (x === undefined) { x = 0; }
+      if (y === undefined) { y = 0; }
 
       this.beginPath();
 
@@ -5186,13 +5188,11 @@ PLAYGROUND.LoadingScreen = {
     },
 
     fillPolygon: function(polygon) {
-      this.beginPath();
       this.polygon(polygon);
       this.fill();
     },
 
     strokePolygon: function(polygon) {
-      this.beginPath();
       this.polygon(polygon);
       this.stroke();
     },
@@ -5861,6 +5861,14 @@ PLAYGROUND.LoadingScreen = {
 
     },
 
+    fill: function() {
+
+      this.context.fill();
+
+      return this;
+
+    },
+
     stroke: function() {
 
       this.context.stroke();
@@ -5964,7 +5972,7 @@ PLAYGROUND.LoadingScreen = {
 
     },
 
-    /* If you think that I am retarded because I use fillRect to set 
+    /* If you think that I am retarded because I use fillRect to set
        pixels - read about premultipled alpha in canvas */
 
     writeMeta: function(data) {
@@ -6403,6 +6411,7 @@ PLAYGROUND.LoadingScreen = {
   return cq;
 
 })();
+
 
 /* file: src/layer/Layer.js */
 

--- a/build/playground.js
+++ b/build/playground.js
@@ -4074,19 +4074,19 @@ PLAYGROUND.LoadingScreen = {
 
 /* file: src/lib/CanvasQuery.js */
 
-/*     
+/*
 
   Canvas Query r6
-  
+
   http://canvasquery.com
-  
+
   (c) 2012-2015 http://rezoner.net
-  
+
   Canvas Query may be freely distributed under the MIT license.
 
   r5
 
-  ! fixed: leaking arguments in fastApply bailing out optimization 
+  ! fixed: leaking arguments in fastApply bailing out optimization
   + cacheText
   + compare
   + checkerboard
@@ -4534,10 +4534,10 @@ PLAYGROUND.LoadingScreen = {
       if (arguments[0] instanceof Image || arguments[0] instanceof Canvas || arguments[0] instanceof ImageBitmap) {
 
         var image = arguments[0];
-        
+
         result.width = image.width;
         result.height = image.height;
-        
+
         result.getContext("2d").drawImage(image, 0, 0);
 
       } else {
@@ -5170,6 +5170,8 @@ PLAYGROUND.LoadingScreen = {
 
 
     polygon: function(array, x, y) {
+      if (x === undefined) { x = 0; }
+      if (y === undefined) { y = 0; }
 
       this.beginPath();
 
@@ -5185,13 +5187,11 @@ PLAYGROUND.LoadingScreen = {
     },
 
     fillPolygon: function(polygon) {
-      this.beginPath();
       this.polygon(polygon);
       this.fill();
     },
 
     strokePolygon: function(polygon) {
-      this.beginPath();
       this.polygon(polygon);
       this.stroke();
     },
@@ -5860,6 +5860,14 @@ PLAYGROUND.LoadingScreen = {
 
     },
 
+    fill: function() {
+
+      this.context.fill();
+
+      return this;
+
+    },
+
     stroke: function() {
 
       this.context.stroke();
@@ -5963,7 +5971,7 @@ PLAYGROUND.LoadingScreen = {
 
     },
 
-    /* If you think that I am retarded because I use fillRect to set 
+    /* If you think that I am retarded because I use fillRect to set
        pixels - read about premultipled alpha in canvas */
 
     writeMeta: function(data) {
@@ -6402,6 +6410,7 @@ PLAYGROUND.LoadingScreen = {
   return cq;
 
 })();
+
 
 /* file: src/layer/Layer.js */
 

--- a/src/lib/CanvasQuery.js
+++ b/src/lib/CanvasQuery.js
@@ -1,16 +1,16 @@
-/*     
+/*
 
   Canvas Query r6
-  
+
   http://canvasquery.com
-  
+
   (c) 2012-2015 http://rezoner.net
-  
+
   Canvas Query may be freely distributed under the MIT license.
 
   r5
 
-  ! fixed: leaking arguments in fastApply bailing out optimization 
+  ! fixed: leaking arguments in fastApply bailing out optimization
   + cacheText
   + compare
   + checkerboard
@@ -458,10 +458,10 @@
       if (arguments[0] instanceof Image || arguments[0] instanceof Canvas || arguments[0] instanceof ImageBitmap) {
 
         var image = arguments[0];
-        
+
         result.width = image.width;
         result.height = image.height;
-        
+
         result.getContext("2d").drawImage(image, 0, 0);
 
       } else {
@@ -1094,6 +1094,8 @@
 
 
     polygon: function(array, x, y) {
+      if (x === undefined) { x = 0; }
+      if (y === undefined) { y = 0; }
 
       this.beginPath();
 
@@ -1109,13 +1111,11 @@
     },
 
     fillPolygon: function(polygon) {
-      this.beginPath();
       this.polygon(polygon);
       this.fill();
     },
 
     strokePolygon: function(polygon) {
-      this.beginPath();
       this.polygon(polygon);
       this.stroke();
     },
@@ -1784,6 +1784,14 @@
 
     },
 
+    fill: function() {
+
+      this.context.fill();
+
+      return this;
+
+    },
+
     stroke: function() {
 
       this.context.stroke();
@@ -1887,7 +1895,7 @@
 
     },
 
-    /* If you think that I am retarded because I use fillRect to set 
+    /* If you think that I am retarded because I use fillRect to set
        pixels - read about premultipled alpha in canvas */
 
     writeMeta: function(data) {


### PR DESCRIPTION
added missing `.fill()` method;
fixed `.polygon()` method, supporting default values of 0 for x and y;
fixed `.fillPolygon()` and `.strokePolygon()` methods, removing duplicate call to `.beginPath()`.

Sorry if I mangled the whitespace in the file and fixed in the master branch. The thing is polygon is severely borked without these changes. Great work on playgroundjs!
