### PR TITLE
Add "var" to for-loop

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -246,7 +246,7 @@ PLAYGROUND.Tween.prototype = {
       this.before = [];
       this.types = [];
 
-      for (i = 0; i < this.keys.length; i++) {
+      for (var i = 0; i < this.keys.length; i++) {
 
         var key = this.keys[i];
         var value = this.context[key];


### PR DESCRIPTION
When using playground with webpack and babel, the build-system was complaining about the missing "var".
See: https://www.dropbox.com/s/3pxlpgefqx8t63b/Screenshot%202016-03-17%2016.51.53.png?dl=0
