### PR TITLE
setting global PLAYGROUND variable to an empty object in commonJS build script

### DIFF
--- a/build.js
+++ b/build.js
@@ -59,7 +59,7 @@ for (var key in builds) {
 
   output.to("build/" + key);
 
-  output = 'var PLAYGROUND;\n' + output;
+  output = 'var PLAYGROUND = {};\n' + output;
   output += '\nmodule.exports = playground;';
   output += 'playground.Application = PLAYGROUND.Application;';
   output.to("build/commonjs/" + key);

--- a/build/commonjs/playground-base.js
+++ b/build/commonjs/playground-base.js
@@ -1,4 +1,4 @@
-var PLAYGROUND;
+var PLAYGROUND = {};
 
 
 /* file: license.txt */

--- a/build/commonjs/playground.js
+++ b/build/commonjs/playground.js
@@ -1,4 +1,4 @@
-var PLAYGROUND;
+var PLAYGROUND = {};
 
 
 /* file: license.txt */


### PR DESCRIPTION
When loading playground using webpack I was seeing the following error: `playground.js:499 Uncaught TypeError: Cannot set property 'MOBILE' of undefined`. I had a look at the source and it seems like it was because of this part:

```
window.PLAYGROUND = {};

PLAYGROUND.MOBILE = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
```

When loaded by webpack, `window.PLAYGROUND` !== the global `PLAYGROUND` variable added by the build script, so I updated the build script to initialise PLAYGROUND to an empty object and it seems to work fine with webpack now :)
