### PR TITLE
Bugfix: Iterate over array in 'loadImages'

### DIFF
--- a/src/Application.js
+++ b/src/Application.js
@@ -589,7 +589,16 @@ PLAYGROUND.Application.prototype = {
 
       /* polymorphism at its finest */
 
-      if (typeof arg === "object") {
+      if (arg.constructor === Array) {
+
+        for(var key = 0; key < arg.length; key++) {
+
+            promises = promises.concat(this.loadImages(arg[key]));
+
+        }
+
+      }
+      else if (typeof arg === "object") {
 
         for (var key in arg) promises = promises.concat(this.loadImages(arg[key]));
 


### PR DESCRIPTION
# Problem

Let's assume we have this code:

```
this.loadImages('a.png', 'b.png');
```

Now, we know for sure we want to load a.png and b.png,
This is easy as pie, we just need to iterate over `arguments`.

However we can also write:

```
this.loadImages(['a.png', 'b.png']);
```

This is more tricky. We need to distinguish a string from array.
So what do we do?
We check if arg is an object.

If it's true, we just iterate over all elements in array.
Well, how do we do it?
We use

```
for (var key in arg) ...
```

And it usually works just fine.
What is more now we can write

```
this.loadImages({a: 'a.png', b: 'b.png });
```

and it should work.

But there is one small problem:
**Using `for ... in` with array iteration is a bad idea**

Somewhere deep in your or other JavaScript library there can be something like this:

```
Array.prototype.foo = 1; //or
Array.prototype.remove = function() { ...
```

Now foo is a part of **EVERY** array and it will show up inside our
`for ... in` loop as a value of `key`.
# Solution

_I'm not sure if this is 100% correct solution_

When we operate on array we should do basic for loop

```
for(var key = 0; key < arg.length; key++)
```

Now we will iterate only over our desired elements.
But this has drawback - we can't use object syntax anymore.

So before loop we could check if object is an Array.
Unless it is we use old for `(var key in arg)` method, otherwise new `for(key = 0; ...`.
