### PR TITLE
Bugfix: Ensure that layer exists

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -46,10 +46,9 @@ PLAYGROUND.Canvas.prototype = {
 
     var layer = app.layer;
 
-    layer.useAlpha = false;
-
     if (!layer) return;
-
+    
+    layer.useAlpha = false;
     layer.width = app.width;
     layer.height = app.height;
 


### PR DESCRIPTION
We check if layer is available after using it. So I moved `layer.useAlpha` _after_ checking if layer is null or undefined.

It caused sometimes:

> TypeError: Cannot set property 'useAlpha' of undefined
> For example when another script messed with document or canvas height.

(I'm sorry for another PR,  I picked wrong branch)
